### PR TITLE
[bin] fix bug in retrieve_blender_from_path

### DIFF
--- a/bin/morse.in
+++ b/bin/morse.in
@@ -58,7 +58,7 @@ def retrieve_blender_from_path():
         blenders_in_path = subprocess.Popen(
                                 ['which', '-a', 'blender'], 
                                 stdout=subprocess.PIPE).communicate()[0]
-        res = str(blenders_in_path).split('\n')[:-1]
+        res = blenders_in_path.decode().splitlines()
     except OSError:
         return []
     


### PR DESCRIPTION
splitlines should work on MacOS as well
str(bytes) to bytes.decode()
