### PR TITLE
[builder] environment: add set_stereo method

### DIFF
--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -401,6 +401,12 @@ class Environment(AbstractComponent):
     def set_debug(self, debug=True):
         bpy.app.debug = debug
 
+    def set_stereo(self, stereo='STEREO'):
+        """ set_stereo
+        :param stereo: enum in ['NONE', 'STEREO', 'DOME'], default 'STEREO'
+        """
+        bpy.context.scene.game_settings.stereo = stereo
+
     def configure_multinode(self, protocol='socket', 
             server_address='localhost', server_port='65000', distribution=None):
         self._protocol = protocol


### PR DESCRIPTION
see: bpy.context.scene.game_settings.stereo
 http://www.blender.org/documentation/blender_python_api_2_61_release/bpy.types.SceneGameData.html#bpy.types.SceneGameData.stereo 
