### PR TITLE
[builder] environment: add set_auto_start method

### DIFF
--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -398,6 +398,10 @@ class Environment(AbstractComponent):
                     if space.type == 'VIEW_3D':
                         space.viewport_shade = viewport_shade
 
+    def set_auto_start(self, auto_start=True):
+        bpy.context.scene.render.engine = 'BLENDER_GAME'
+        bpy.context.scene.game_settings.use_auto_start = auto_start
+
     def set_debug(self, debug=True):
         bpy.app.debug = debug
 


### PR DESCRIPTION
equivalent to morse run script.py

 http://www.blender.org/documentation/blender_python_api_2_61_release/bpy.types.SceneGameData.html#bpy.types.SceneGameData.use_auto_start 
