### PR TITLE
[doc] builder: sick resolution can not be changed

### DIFF
--- a/doc/morse/dev/builder.rst
+++ b/doc/morse/dev/builder.rst
@@ -170,10 +170,8 @@ You can modify the game-properties of any components within Python
 
 .. code-block:: python
 
-    sick = Sensor('sick')
-    sick.properties(resolution = 1)
-    cam = Sensor('video_camera')
-    cam.properties(cam_width = 128, cam_height = 128)
+    camera = Sensor('video_camera')
+    camera.properties(cam_width = 128, cam_height = 128)
 
 Middleware configuration
 ++++++++++++++++++++++++

--- a/doc/morse/dev/builder_example.rst
+++ b/doc/morse/dev/builder_example.rst
@@ -65,7 +65,6 @@ You can modify the game-properties of any components within Python
 .. code-block:: python
 
     sick = Sensor('sick')
-    sick.properties(resolution = 1)
     cam = Sensor('video_camera')
     cam.properties(cam_width = 128, cam_height = 128)
 
@@ -157,7 +156,6 @@ Example
     sick = Sensor('sick')
     sick.translate(x=0.18,z=0.94)
     atrv.append(sick)
-    sick.properties(resolution = 1)
 
     # Append a camera
     cam = Sensor('video_camera')


### PR DESCRIPTION
sick resolution can not be changed in python, 
only by changing meshes of Arc_XXX.

Arc_180 = 180°, resolution = 1 (1_180 rays)
Arc_270 = 270°, resolution = 0.25 (4_270 rays)
