### PR TITLE
Set glsl

### DIFF
--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -435,9 +435,19 @@ class Environment(AbstractComponent):
         # Show the entire viewport in the display window, 
         # viewing more horizontally or vertically.
         bpy.context.scene.game_settings.frame_type = 'EXTEND'
+        # Start player with a visible mouse cursor
+        bpy.context.scene.game_settings.show_mouse = True
         # Set default camera
         bpy.context.scene.camera = camera_fp
         self._created = True
+
+    def set_horizon_color(self, color=(0.05, 0.22, 0.4)):
+        """ Set the horizon color
+        :param color: (0.0, 0.0, 0.0) < (R, B, G) < (1.0, 1.0, 1.0) 
+                      default: dark azure (0.05, 0.22, 0.4)
+        """
+        # Set the color at the horizon to dark azure
+        bpy.context.scene.world.horizon_color = color
 
     def show_debug_properties(self, value=True):
         if isinstance(value, bool):


### PR DESCRIPTION
- Make sure OpenGL shading language shaders (GLSL) is the material mode to use for rendering
- Set the unit system to use for button display (in edit mode) to metric
- Select the type of Framing to Extend
  Show the entire viewport in the display window, viewing more horizontally or vertically.
- Set default camera
- Add method to set the color at the horizon (default to dark azure)
