### PR TITLE
[builder] select_name to select_pattern

### DIFF
--- a/src/morse/builder/abstractcomponent.py
+++ b/src/morse/builder/abstractcomponent.py
@@ -147,7 +147,8 @@ class AbstractComponent(object):
                 optional, auto-detect, default=None)
         """
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = self.name)
+        bpy.ops.object.select_pattern(pattern=self.name, case_sensitive=True,
+                                      extend=False)
         bpy.ops.object.game_property_new()
         prop = self._blendobj.game.properties
         # select the last property in the list (which is the one we just added)

--- a/src/morse/builder/creator.py
+++ b/src/morse/builder/creator.py
@@ -36,7 +36,8 @@ class ComponentCreator(morse.builder.morsebuilder.AbstractComponent):
         self._blendobj.name = name
         self._blendname = filename # for middleware configuration
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = self._blendobj.name)
+        bpy.ops.object.select_pattern(pattern=self._blendobj.name,
+                                      case_sensitive=True, extend=False)
         bpy.ops.logic.sensor_add() # default is Always sensor
         sensor = self._blendobj.game.sensors[-1]
         sensor.use_pulse_true_level = True

--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -243,7 +243,8 @@ class Component(AbstractComponent):
 
         # add Game Logic sensor and controller to simulate the component
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = obj.name)
+        bpy.ops.object.select_pattern(pattern=obj.name, case_sensitive=True,
+                                      extend=False)
         bpy.ops.logic.sensor_add() # default is Always sensor
         sensor = obj.game.sensors[-1]
         sensor.use_pulse_true_level = True
@@ -425,7 +426,8 @@ class Environment(AbstractComponent):
         camera_fp.rotation_euler = self._camera_rotation
         # Make CameraFP the active camera
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = 'CameraFP')
+        bpy.ops.object.select_pattern(pattern='CameraFP', case_sensitive=True,
+                                      extend=False)
         self._created = True
 
     def show_debug_properties(self, value=True):

--- a/src/morse/builder/sensors.py
+++ b/src/morse/builder/sensors.py
@@ -95,7 +95,8 @@ class Camera(morse.builder.creator.SensorCreator):
         self.frequency(3)
         # add toggle capture action (`Space` key)
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = self._blendobj.name)
+        bpy.ops.object.select_pattern(pattern=self._blendobj.name,
+                                      case_sensitive=True, extend=False)
         bpy.ops.logic.sensor_add(type="KEYBOARD")
         sensor = self._blendobj.game.sensors[-1]
         sensor.key = 'SPACE'


### PR DESCRIPTION
for Blender 2.62 which droped select_name method
select_name(name) = select_pattern(pattern=name, case_sensitive=True, extend=False)
