### PR TITLE
[bpy] 2.62 drop select_name

### DIFF
--- a/addons/io_import_morse_path.py
+++ b/addons/io_import_morse_path.py
@@ -141,7 +141,9 @@ class MorseLoadTextPath(bpy.types.Operator):
 
         # A trick to make the selection and join correctly
         # First select one of the segments. This will be the Active Object
-        bpy.ops.object.select_name(name="Segment1")
+        active_segment = bpy.data.objects["Segment1"]
+        active_segment.select = True
+        bpy.context.scene.objects.active = active_segment
         # Then select all the rest. This does not change the Active Object
         bpy.ops.object.select_pattern(pattern="Segment*")
         # Join. The active Object must be selected

--- a/addons/io_import_morse_text.py
+++ b/addons/io_import_morse_text.py
@@ -148,7 +148,9 @@ class MorseLoadTextCoords(bpy.types.Operator):
 
         # A trick to make the selection and join correctly
         # First select one of the segments. This will be the Active Object
-        bpy.ops.object.select_name(name="Segment1")
+        active_segment = bpy.data.objects["Segment1"]
+        active_segment.select = True
+        bpy.context.scene.objects.active = active_segment
         # Then select all the rest. This does not change the Active Object
         bpy.ops.object.select_pattern(pattern="Segment*")
         # Join. The active Object must be selected

--- a/src/morse/builder/abstractcomponent.py
+++ b/src/morse/builder/abstractcomponent.py
@@ -147,11 +147,8 @@ class AbstractComponent(object):
                 optional, auto-detect, default=None)
         """
         bpy.ops.object.select_all(action = 'DESELECT')
-        #bpy.ops.object.select_pattern(pattern = self.name, extend=False)
-        #bpy.ops.object.select_name(name = self.name)
-        blend_obj = bpy.data.objects[self.name]
-        blend_obj.select = True
-        bpy.context.scene.objects.active = blend_obj
+        self._blendobj.select = True
+        bpy.context.scene.objects.active = self._blendobj
         bpy.ops.object.game_property_new()
         prop = self._blendobj.game.properties
         # select the last property in the list (which is the one we just added)

--- a/src/morse/builder/creator.py
+++ b/src/morse/builder/creator.py
@@ -36,7 +36,8 @@ class ComponentCreator(morse.builder.morsebuilder.AbstractComponent):
         self._blendobj.name = name
         self._blendname = filename # for middleware configuration
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = self._blendobj.name)
+        self._blendobj.select = True
+        bpy.context.scene.objects.active = self._blendobj
         bpy.ops.logic.sensor_add() # default is Always sensor
         sensor = self._blendobj.game.sensors[-1]
         sensor.use_pulse_true_level = True

--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -244,7 +244,8 @@ class Component(AbstractComponent):
 
         # add Game Logic sensor and controller to simulate the component
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = obj.name)
+        obj.select = True
+        bpy.context.scene.objects.active = obj
         bpy.ops.logic.sensor_add() # default is Always sensor
         sensor = obj.game.sensors[-1]
         sensor.use_pulse_true_level = True

--- a/src/morse/builder/sensors.py
+++ b/src/morse/builder/sensors.py
@@ -95,7 +95,8 @@ class Camera(morse.builder.creator.SensorCreator):
         self.frequency(3)
         # add toggle capture action (`Space` key)
         bpy.ops.object.select_all(action = 'DESELECT')
-        bpy.ops.object.select_name(name = self._blendobj.name)
+        self._blendobj.select = True
+        bpy.context.scene.objects.active = self._blendobj
         bpy.ops.logic.sensor_add(type="KEYBOARD")
         sensor = self._blendobj.game.sensors[-1]
         sensor.key = 'SPACE'


### PR DESCRIPTION
Campbell Barton (bpy master) wrote:
"Another is...
 bpy.ops.object.select_name(name=arm.name)

This should be replaces with...
 arm.select = True
 bpy.context.scene.objects.active = arm
" - http://lists.blender.org/pipermail/bf-python/2011-December/005759.html

checked with: `grep "select_name" . -R --exclude="*.pyc" --exclude-dir="build" --exclude-dir=".git"`
