### PR TITLE
[builder] resolve ambiguity in frequency setter

### DIFF
--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -253,12 +253,17 @@ class Component(AbstractComponent):
         controller.mode = 'MODULE'
         controller.module = calling_module
         controller.link(sensor = sensor)
-    def frequency(self, delay=0):
+    def frequency(self, frequency=None, delay=0):
         """ Set the frequency delay for the call of the Python module
 
+        :param frequency: (int) Desired frequency, 
+            0 < frequency < logic tics
         :param delay: (int) Delay between repeated pulses
             (in logic tics, 0 = no delay)
+            if frequency is set, delay is obtained by fps / frequency.
         """
+        if frequency:
+            delay = bpy.context.scene.game_settings.fps // frequency
         sensors = [s for s in self._blendobj.game.sensors if s.type == 'ALWAYS']
         if len(sensors) > 1:
             logger.warning(self.name + " has too many Game Logic sensors to "+\


### PR DESCRIPTION
comes from the "frequency" attribute of game logic sensors, which is a frequency delay, see:

http://www.blender.org/documentation/blender_python_api_2_61_release/bpy.types.Sensor.html#bpy.types.Sensor.frequency

obj.game.sensors[0].frequency:
Delay between repeated pulses(in logic tics, 0=no delay)

Type :  int in [0, 10000], default 0

http://www.blender.org/documentation/blender_python_api_2_61_release/bpy.types.SceneGameData.html#bpy.types.SceneGameData.fps

bpy.context.scene.game_settings.fps:
Nominal number of game frames per second (physics fixed timestep = 1/fps, independently of actual frame rate)

Type :  int in [1, 250], default 0
