### PR TITLE
fix setting of frequency of sensors/actuators

### DIFF
--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -283,7 +283,7 @@ class Component(AbstractComponent):
             if frequency is set, delay is obtained by fps / frequency.
         """
         if frequency:
-            delay = bpy.context.scene.game_settings.fps // frequency
+            delay = max(0, bpy.context.scene.game_settings.fps // frequency - 1)
         sensors = [s for s in self._blendobj.game.sensors if s.type == 'ALWAYS']
         if len(sensors) > 1:
             logger.warning(self.name + " has too many Game Logic sensors to "+\


### PR DESCRIPTION
When trying to set the frequency of a sensor/actuator to the same as the fps, it was actually set to half of the fps (delay was 1).
