### PR TITLE
Documentation fix for GPS

### DIFF
--- a/doc/morse/user/compatibility_matrix.csv
+++ b/doc/morse/user/compatibility_matrix.csv
@@ -5,7 +5,7 @@ Communications ,
 Sensors,
 ``Accelerometer``,            ✔,               ✔,           ✔,              ✔ ``Twist``,     ✘,																	✔ 
 ``Battery``,				  ✔,			   ✔,			✔,				✔ ``Float32``,	✘,																	✔
-``GPS``,                      ✔,               ✔,           ✔,              ✔ ``PoseStamped``,✔ ``POM_ME_POS``,								✔
+``GPS``,                      ✔,               ✔,           ✔,              ✔ ``NavSatFix``,✔ ``POM_ME_POS``,								✔
 ``Gyroscope``,                ✔,               ✔,           ✔,              ✘,                ✔ ``POM_ME_POS``,												✔
 ``Human posture``,            ✔,               ✔,           ✔,              ✘,               ✔ ``SPARK_CONFIGURATION``,											✘
 ``IMU``,		              ✔,               ✔,           ✔,              ✔ ``Imu``,     ✘,																	✔


### PR DESCRIPTION
I just fix the documentation according to the type of GPS msg for ROS in the compatibility matrix.
