### PR TITLE
[blender] fix camera switching bug

### DIFF
--- a/src/morse/blender/view_camera.py
+++ b/src/morse/blender/view_camera.py
@@ -17,6 +17,7 @@ from morse.core import blenderapi
 
 start_position = []
 start_orientation = []
+keyboard_ctrl_objects = []
 
 def store_default(contr):
     """ Save the initial position and orientation of the camera """
@@ -28,7 +29,16 @@ def store_default(contr):
     start_position = mathutils.Vector(camera.worldPosition)
     start_orientation = mathutils.Matrix(camera.worldOrientation)
 
-
+    # look for objects that define the move_cameraFP property to 
+    # disable keyboard control of the camera
+    scene = blenderapi.scene()
+    if not scene:
+        # not ready, main reload(blenderapi)
+        return
+    for obj in scene.objects:
+        if 'move_cameraFP' in obj.getPropertyNames():
+            keyboard_ctrl_objects.append(obj)
+                
 def reset_position(contr):
     """ Put the camera in the initial position and orientation """
     camera = contr.owner
@@ -51,11 +61,10 @@ def move(contr):
     if camera != scene.active_camera:
         return
 
-
-    for obj in scene.objects:
-        if 'move_cameraFP' in obj.getPropertyNames():
-            if not obj['move_cameraFP']:
-                return
+    # Do not move the camera if another object has set move_cameraFP 
+    for obj in keyboard_ctrl_objects:
+        if not obj['move_cameraFP']:
+            return
 
     # set the movement speed
     speed = camera['Speed']


### PR DESCRIPTION
In 1.0 when using the world camera with a human in a scene created with a builder script, the movement keys move both the camera and the human when movement control is set to control the human only.  Controlling the camera only works fine.  

In camera_view, an object named "Human" is searched for to control the movement keys.  In the new version of builder the object names changes to the name used in the builder script so if the object is named human (human = Human()) then the object is never found to check it's game properties.  This would also be a problem if (like in the instructions at: http://www.openrobots.org/morse/doc/stable/user/builder.html) the human name was changed to something else like "jerry".

I modified the camera movement code to look for any object with a move_cameraFP game property to determine if the world camera should be moved.  This would also allow for other components besides a human to make use of the keyboard keys and disable camera movement.
