### PR TITLE
[ros][fix] mathutils.Quaternion() expects a tuple

### DIFF
--- a/src/morse/middleware/ros/orientation.py
+++ b/src/morse/middleware/ros/orientation.py
@@ -9,7 +9,7 @@ class QuaternionReader(ROSReader):
     ros_class = Quaternion
 
     def update(self, message):
-        quaternion = mathutils.Quaternion(message)
+        quaternion = mathutils.Quaternion((message.w, message.x, message.y, message.z))
         euler = quaternion.to_euler()
         self.data["roll"] = euler.x
         self.data["pitch"] = euler.y

--- a/src/morse/middleware/ros/read_pose.py
+++ b/src/morse/middleware/ros/read_pose.py
@@ -14,7 +14,7 @@ class PoseReader(ROSReader):
         self.data["y"] = message.position.y
         self.data["z"] = message.position.z
 
-        quaternion = mathutils.Quaternion(message.orientation)
+        quaternion = mathutils.Quaternion((message.orientation.w, message.orientation.x, message.orientation.y, message.orientation.z))
         euler = quaternion.to_euler()
         self.data['roll'] = euler.x
         self.data['pitch'] = euler.y


### PR DESCRIPTION
Fixes MORSE crash on subscribing to quaterion or pose message

This fix should also be applied to 1.0_STABLE 
