### PR TITLE
Pymorse

### DIFF
--- a/bindings/pymorse/src/pymorse/pymorse.py
+++ b/bindings/pymorse/src/pymorse/pymorse.py
@@ -623,10 +623,13 @@ class Morse():
 
     def _add_component(self, robot, fqn, details):
         stream = details.get('stream', None)
+        port = None
         if stream:
-            port = self.get_stream_port(fqn)
-        else:
-            port = None
+            try:
+                port = self.get_stream_port(fqn)
+            except MorseServiceFailed:
+                pymorselogger.debug('Component <%s> has a non-socket stream: datastream via pymorse not supported', fqn)
+                stream = None
 
         services = details.get('services', [])
 

--- a/src/morse/middleware/socket_datastream.py
+++ b/src/morse/middleware/socket_datastream.py
@@ -6,6 +6,7 @@ from morse.core.datastream import Datastream
 from morse.helpers.transformation import Transformation3d
 from morse.middleware import AbstractDatastream
 from morse.core import services
+from morse.core.exceptions import MorseRPCInvokationError
 
 try:
     import mathutils
@@ -174,7 +175,10 @@ class Socket(Datastream):
             port = self._component_nameservice[name]
         except KeyError:
             pass
-
+        
+        if port < 0:
+            raise MorseRPCInvokationError("Stream unavailable for component %s" % name)
+        
         return port
 
     def get_all_stream_ports(self):


### PR DESCRIPTION
When a component has a datastream that is
not socket, the get_stream_port service
now fails. This failure is correctly handled
by pymorse that does not fail anymore on creating the
associated Stream.
