### PR TITLE
[modifiers] noise: separate std_dev for each axis

### DIFF
--- a/src/morse/modifiers/imu_noise.py
+++ b/src/morse/modifiers/imu_noise.py
@@ -1,6 +1,5 @@
 import logging; logger = logging.getLogger("morse." + __name__)
 import random
-from collections import defaultdict
 
 from morse.helpers.components import add_property
 from morse.modifiers.abstract_modifier import AbstractModifier
@@ -22,31 +21,25 @@ class IMUNoiseModifier(AbstractModifier):
     def initialize(self):
         gyro_std = self.parameter("gyro_std", default=0.5)
         if isinstance(gyro_std, dict):
-            self._gyro_std_dev = defaultdict(lambda: 0.0, gyro_std)
+            self._gyro_std_dev = gyro_std
         else:
             self._gyro_std_dev = {'x': float(gyro_std), 'y': float(gyro_std), 'z': float(gyro_std)}
         accel_std = self.parameter("accel_std", default=0.5)
         if isinstance(accel_std, dict):
-            self._accel_std_dev = defaultdict(lambda: 0.0, accel_std)
+            self._accel_std_dev = accel_std
         else:
             self._accel_std_dev = {'x': float(accel_std), 'y': float(accel_std), 'z': float(accel_std)}
-        logger.info("IMU Noise standard deviations: gyro x:%.4f, y:%.4f, z:%.4f,  accel x:%.4f, y:%.4f, z:%.4f,"
-                    % (self._gyro_std_dev['x'], self._gyro_std_dev['y'], self._gyro_std_dev['z'],
-                       self._accel_std_dev['x'], self._accel_std_dev['y'], self._accel_std_dev['z']))
+        logger.info("IMU Noise standard deviations: gyro x:%.4f, y:%.4f, z:%.4f,  accel x:%.4f, y:%.4f, z:%.4f,",
+                    self._gyro_std_dev.get('x', 0), self._gyro_std_dev.get('y', 0), self._gyro_std_dev.get('z'),
+                    self._accel_std_dev.get('x', 0), self._accel_std_dev.get('y', 0), self._accel_std_dev.get('z', 0))
 
     def modify(self):
-        try:
-            self.data['angular_velocity'][0] = \
-                random.gauss(self.data['angular_velocity'][0], self._gyro_std_dev['x'])
-            self.data['linear_acceleration'][0] = \
-                random.gauss(self.data['linear_acceleration'][0], self._accel_std_dev['x'])
-            self.data['angular_velocity'][1] = \
-                random.gauss(self.data['angular_velocity'][1], self._gyro_std_dev['y'])
-            self.data['linear_acceleration'][1] = \
-                random.gauss(self.data['linear_acceleration'][1], self._accel_std_dev['y'])
-            self.data['angular_velocity'][2] = \
-                random.gauss(self.data['angular_velocity'][2], self._gyro_std_dev['z'])
-            self.data['linear_acceleration'][2] = \
-                random.gauss(self.data['linear_acceleration'][2], self._accel_std_dev['z'])
-        except KeyError as detail:
-            self.key_error(detail)
+        axes = ['x', 'y', 'z']
+        for i in range(0, 3):
+            if axes[i] in self._gyro_std_dev:
+                self.data['angular_velocity'][i] = \
+                    random.gauss(self.data['angular_velocity'][i], self._gyro_std_dev[axes[i]])
+            if axes[i] in self._accel_std_dev:
+                self.data['linear_acceleration'][i] = \
+                    random.gauss(self.data['linear_acceleration'][i], self._accel_std_dev[axes[i]])
+

--- a/src/morse/modifiers/pose_noise.py
+++ b/src/morse/modifiers/pose_noise.py
@@ -1,8 +1,7 @@
 import logging; logger = logging.getLogger("morse." + __name__)
 import random
 from math import radians, degrees, cos
-import mathutils
-from collections import defaultdict
+from mathutils import Vector, Quaternion
 
 from morse.helpers.components import add_property
 from morse.modifiers.abstract_modifier import AbstractModifier
@@ -38,70 +37,70 @@ class NoiseModifier(AbstractModifier):
     def initialize(self):
         pos_std = self.parameter("pos_std", default=0.05)
         if isinstance(pos_std, dict):
-            self._pos_std_dev = defaultdict(lambda: 0.0, pos_std)
+            self._pos_std_dev = pos_std
         else:
             self._pos_std_dev = {'x': float(pos_std), 'y': float(pos_std), 'z': float(pos_std)}
         rot_std = self.parameter("rot_std", default=radians(5))
         if isinstance(rot_std, dict):
-            self._rot_std_dev = defaultdict(lambda: 0.0, rot_std)
+            self._rot_std_dev = rot_std
         else:
             self._rot_std_dev = {'roll': float(rot_std), 'pitch': float(rot_std), 'yaw': float(rot_std)}
         self._2D = bool(self.parameter("_2D", default=False))
         if self._2D:
-            logger.info("Noise modifier standard deviations: x:%.4f, y:%.4f, yaw:%.3f deg"
-                    % (self._pos_std_dev['x'], self._pos_std_dev['y'], degrees(self._rot_std_dev['yaw'])))
+            logger.info("Noise modifier standard deviations: x:%.4f, y:%.4f, yaw:%.3f deg",
+                        self._pos_std_dev.get('x', 0),
+                        self._pos_std_dev.get('y', 0),
+                        degrees(self._rot_std_dev.get('yaw', 0)))
         else:
-            logger.info("Noise modifier standard deviations: x:%.4f, y:%.4f, z:%.4f, roll:%.3f deg, pitch:%.3f deg, yaw:%.3f deg"
-                    % (self._pos_std_dev['x'], self._pos_std_dev['y'], self._pos_std_dev['z'],
-                       degrees(self._rot_std_dev['roll']), degrees(self._rot_std_dev['pitch']), degrees(self._rot_std_dev['yaw'])))
+            logger.info("Noise modifier standard deviations: x:%.4f, y:%.4f, z:%.4f, "
+                        "roll:%.3f deg, pitch:%.3f deg, yaw:%.3f deg",
+                        self._pos_std_dev.get('x', 0),
+                        self._pos_std_dev.get('y', 0),
+                        self._pos_std_dev.get('z', 0),
+                        degrees(self._rot_std_dev.get('roll', 0)),
+                        degrees(self._rot_std_dev.get('pitch', 0)),
+                        degrees(self._rot_std_dev.get('yaw', 0)))
 
 class PositionNoiseModifier(NoiseModifier):
     """ Add a gaussian noise to a position 
     """
     def modify(self):
-        try:
-            data_vars = ['x', 'y']
-            if not self._2D:
-                data_vars.append('z')
-            for variable in data_vars:
+        data_vars = ['x', 'y']
+        if not self._2D:
+            data_vars.append('z')
+        for variable in data_vars:
+            if variable in self.data and variable in self._pos_std_dev:
                 self.data[variable] = random.gauss(self.data[variable], self._pos_std_dev[variable])
-        except KeyError as detail:
-            self.key_error(detail)
 
 class OrientationNoiseModifier(NoiseModifier):
     """ Add a gaussian noise to an orientation 
     """
     def modify(self):
+        data_vars = []
+        if not self._2D:
+            data_vars.append('roll')
+            data_vars.append('pitch')
+        data_vars.append('yaw')
         # generate a gaussian noise rotation vector
-        rot_vec = mathutils.Vector((0.0, 0.0, 0.0))
-        if self._2D:
-            rot_vec[0] = random.gauss(rot_vec[0], self._rot_std_dev['roll'])
-            rot_vec[1] = random.gauss(rot_vec[1], self._rot_std_dev['pitch'])
-        else:
-            rot_vec[0] = 0.0
-            rot_vec[1] = 0.0
-        rot_vec[2] = random.gauss(rot_vec[2], self._rot_std_dev['yaw'])
+        rot_vec = Vector((0.0, 0.0, 0.0))
+        for i in range(0, 3):
+            if data_vars[i] in self._rot_std_dev:
+                rot_vec[i] = random.gauss(rot_vec[i], self._rot_std_dev[data_vars[i]])
         # convert rotation vector to a quaternion representing the random rotation
         angle = rot_vec.length
         if angle > 0:
             axis = rot_vec / angle
-            noise_quat = mathutils.Quaternion(axis, angle)
+            noise_quat = Quaternion(axis, angle)
         else:
-            noise_quat = mathutils.Quaternion()
+            noise_quat = Quaternion()
             noise_quat.identity()
         try:
             self.data['orientation'] = (noise_quat * self.data['orientation']).normalized()
         except KeyError:
             # for eulers this is a bit crude, maybe should use the noise_quat here as well...
-            try:
-                data_vars = ['yaw']
-                if not self._2D:
-                    data_vars.append('roll')
-                    data_vars.append('pitch')
-                for variable in data_vars:
-                    self.data[variable] = random.gauss(self.data[variable], self._rot_std_dev[variable])
-            except KeyError as detail:
-                self.key_error(detail)
+            for var in data_vars:
+                if var in self.data and var in self._rot_std_dev:
+                    self.data[var] = random.gauss(self.data[var], self._rot_std_dev[var])
 
 class PoseNoiseModifier(PositionNoiseModifier, OrientationNoiseModifier):
     """ Add a gaussian noise to both position and orientation 


### PR DESCRIPTION
This makes it possible to specify the noise for each axis separately as a dict.
If a single value is passed, it is used for all axes.
E.g.:
`pose.alter('', 'morse.modifiers.pose_noise.PoseNoiseModifier', pos_std={'x':0.01, 'y':0.01, 'z':0.1}, rot_std=math.radians(1))`
or
`pose.alter('', 'morse.modifiers.pose_noise.PoseNoiseModifier', pos_std={'x':0.01, 'y':0.01, 'z':0.1}, rot_std={'roll':0.01, 'pitch':0.01, 'yaw':0.05})`

Not sure if it is nicer to use a dict with explicit names for x,y,z and roll,pitch,yaw or a list instead...?
I can do the same for imu_noise if this is a good way to do it.
