### PR TITLE
[testing] Support testing for invalid scenes

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -6,6 +6,7 @@ endmacro()
 
 if (BUILD_CORE_SUPPORT)
 	add_subdirectory(base)
+	add_subdirectory(failures)
 	add_subdirectory(robots/human)
 	add_subdirectory(robots/segway)
 	add_subdirectory(robots/pr2)

--- a/testing/failures/CMakeLists.txt
+++ b/testing/failures/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_morse_test(invalid_builder_syntax)

--- a/testing/failures/invalid_builder_syntax.py
+++ b/testing/failures/invalid_builder_syntax.py
@@ -1,0 +1,56 @@
+#! /usr/bin/env python
+"""
+This script tests how MORSE handles invalid Builder scripts.
+"""
+
+import sys
+import math
+from time import sleep
+from morse.testing.testing import MorseBuilderFailureTestCase
+from pymorse import Morse
+
+# Include this import to be able to use your test file as a regular 
+# builder script, ie, usable with: 'morse [run|exec] <script>.py
+try:
+    from morse.builder import *
+except ImportError:
+    pass
+
+class InvalidName_Test(MorseBuilderFailureTestCase):
+    def setUpEnv(self):
+        """ Defines the test scenario, using the Builder API.
+        """
+        
+        robot = Morsy()
+        robot.name = "toto.toto"
+
+        env = Environment('empty', fastmode = True)
+        env.add_service('socket')
+
+    def test_builder_script(self):
+        with Morse() as simu:
+            pass # we only test the parsing of the script
+
+
+class NoEnvironment_Test(MorseBuilderFailureTestCase):
+    def setUpEnv(self):
+        """ Defines the test scenario, using the Builder API.
+        """
+        
+        robot = Morsy()
+
+        env = Environment('i_do_not_exist', fastmode = True)
+        env.add_service('socket')
+
+    def test_builder_script(self):
+        with Morse() as simu:
+            pass # we only test the parsing of the script
+
+########################## Run these tests ##########################
+if __name__ == "__main__":
+    import unittest
+    from morse.testing.testing import MorseTestRunner
+    suite = unittest.TestLoader().loadTestsFromTestCase(InvalidName_Test)
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(NoEnvironment_Test))
+    sys.exit(not MorseTestRunner().run(suite).wasSuccessful())
+


### PR DESCRIPTION
This commit introduces a new class of tests: MorseBuilderFailureTestcase. These
tests pass if MORSE _properly fails_ to load the scene (ie, it tests that the
GameEngine is not started).

The commit also include 2 tests that currently do not pass (cf bug #374).

While here:
- improve management of PIDs (you do not need to get it from MORSE log,
  Popen.subprocess give it back to us). This allow to kill MORSE even
  if it did not reach the initialization stage.

TODO: I've no example of invalid scripts that are correctly handled by
MORSE, so I could not test that MorseBuilderFailureTestcase actually
pass when MORSE dies before starting the BGE.
