### PR TITLE
Partial fix for shadowing of parent properties in child classes

### DIFF
--- a/src/morse/core/object.py
+++ b/src/morse/core/object.py
@@ -87,14 +87,24 @@ class Object(AbstractObject):
                 if level == "all" or level == self.level:
                     self.local_data[name] = default_value
 
-    def update_properties(self):
+    def update_properties(self, properties = None):
         """
         Takes all registered properties (see add_property), and update
         their values according to the values set in Blender object.
+
+        TODO: this code will only create members each entry in the current
+        object's '_properties' dict + the one in the *direct* parent class. It
+        does not go recursively to high levels.
         """
 
-        if hasattr(self, '_properties'):
-            for name, details in self._properties.items():
+        if hasattr(self, '_properties') or properties:
+            if not properties:
+                properties = self._properties
+
+            if super(self.__class__, self)._properties != properties:
+                self.update_properties(super(self.__class__, self)._properties) # recurse with the _properties of the parent class
+
+            for name, details in properties.items():
                 default_value, type, doc, python_name = details
                 val = default_value
 

--- a/src/morse/sensors/semantic_camera.py
+++ b/src/morse/sensors/semantic_camera.py
@@ -139,7 +139,7 @@ class SemanticCamera(morse.sensors.camera.Camera):
         pos = obj.position
         bbox = [[bb_corner[i] + pos[i] for i in range(3)] for bb_corner in bb]
 
-        if logger.isEnabledFor(DEBUG):
+        if logger.isEnabledFor(logging.DEBUG):
             logger.debug("\n--- NEW TEST ---")
             logger.debug("OBJECT '{0}' AT {1}".format(obj, pos))
             logger.debug("CAMERA '{0}' AT {1}".format(


### PR DESCRIPTION
This bug has been revealed by 138c97bed2a8

The fix is only _partial_  because only the properties set by the direct parent are properly considered. Could not find a way to go all the way up the inheritance stack.

While here, fixed a typo in semantic_camera.
semantic_camera test passes again.
