### PR TITLE
[builder] add Robot.set_friction and test

### DIFF
--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -141,6 +141,15 @@ class Robot(Component):
         if name:
             self.name = name
 
+    def set_friction(self, friction=0.0):
+        """ Set  Coulomb friction coefficient
+
+        :param friction: [0, 100], default 0.0
+        :type  friction: float
+        """
+        for slot in self._bpy_object.material_slots: # ['TireMat']
+            slot.material.physics.friction = friction
+
     def set_mass(self, mass):
         """ Set component's mass
 

--- a/testing/base/CMakeLists.txt
+++ b/testing/base/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_morse_test(base_testing)
 add_morse_test(renaming_testing)
 add_morse_test(builder_wheeled_robot)
+add_morse_test(friction)
 add_morse_test(levels)
 
 # Sensor

--- a/testing/base/friction_testing.py
+++ b/testing/base/friction_testing.py
@@ -1,0 +1,85 @@
+#! /usr/bin/env python
+"""
+This script tests the Robot's 'friction' property.
+
+http://www.blender.org/documentation/blender_python_api_2_68a_release/bpy.types.MaterialPhysics.html#bpy.types.MaterialPhysics.friction
+
+"""
+
+from morse.testing.testing import MorseTestCase
+
+try:
+    # Include this import to be able to use your test file as a regular 
+    # builder script, ie, usable with: 'morse [run|exec] <your test>.py
+    from morse.builder import *
+    from morse.builder.actuators import Light
+except ImportError:
+    pass
+
+import sys
+import time
+from pymorse import Morse
+
+def send_speed(s, v=0, w=0, t=0):
+    s.publish({'v': v, 'w': w})
+    time.sleep(t)
+    s.publish({'v': 0.0, 'w': 0.0})
+
+class FrictionTest(MorseTestCase):
+    def setUpEnv(self):
+        """ Defines the test scenario, using the Builder API. """
+
+        robot1 = ATRV()
+
+        pose = Pose()
+        pose.add_stream('socket')
+        robot1.append(pose)
+
+        motion = MotionVW()
+        motion.add_stream('socket')
+        motion.properties(ControlType='Velocity')
+        robot1.append(motion)
+
+        robot1.translate(y=-1)
+        robot1.set_friction(0)
+
+        robot2 = ATRV()
+
+        pose = Pose()
+        pose.add_stream('socket')
+        robot2.append(pose)
+
+        motion = MotionVW()
+        motion.add_stream('socket')
+        motion.properties(ControlType='Velocity')
+        robot2.append(motion)
+
+        robot2.translate(y=+1)
+        robot2.set_friction(5)
+
+        env = Environment('empty', fastmode = True)
+
+    def test_friction(self):
+        with Morse() as simu:
+
+            precision=0.05
+
+            # Read the start position, it must be (0.0, 0.0, 0.0)
+            for pose_stream in [simu.robot1.pose, simu.robot2.pose]:
+                pose = pose_stream.get()
+                self.assertAlmostEqual(pose['x'], 0.0, delta=precision)
+
+            # Read the start position, it must be (0.0, 0.0, 0.0)
+            for vw_stream in [simu.robot1.motion, simu.robot2.motion]:
+                send_speed(vw_stream, 1.0, 0.0, 2.0)
+
+            pose = simu.robot1.pose.get() # friction = 0 / 100
+            self.assertAlmostEqual(pose['x'], 2.0, delta=precision)
+
+            pose = simu.robot2.pose.get() # friction = 5 / 100
+            self.assertAlmostEqual(pose['x'], 1.1, delta=precision)
+
+########################## Run these tests ##########################
+if __name__ == "__main__":
+    from morse.testing.testing import main
+    main(FrictionTest)


### PR DESCRIPTION
This pull request is a bug, see the attached test for the expected behavior.

The ATRV's documentation [1] talks about an adjustable friction, however, it does not seems to affect the robot's motion.
[1] http://www.openrobots.org/morse/doc/latest/user/robots/atrv.html
