### PR TITLE
[ros] Fix bug with object description

### DIFF
--- a/src/morse/middleware/ros/semantic_camera.py
+++ b/src/morse/middleware/ros/semantic_camera.py
@@ -37,6 +37,8 @@ class SemanticCameraPublisherLisp(ROSPublisherTF):
             # if object has no description, set to '-'
             if obj['description'] == '':
                 description = '-'
+            else:
+                description = obj['description']
 
             # send tf-frame for every object
             self.sendTransform(obj['position'], obj['orientation'], \


### PR DESCRIPTION
Fixed little bug in ros middleware for semantic camera. Without the fix, variable "description" gets referenced before assignment if object description is given.
