### PR TITLE
[pymorse] print message if no concurrent.futures

### DIFF
--- a/bindings/pymorse/src/pymorse/future.py
+++ b/bindings/pymorse/src/pymorse/future.py
@@ -1,3 +1,10 @@
+try:
+    import concurrent.futures
+except ImportError:
+    import sys
+    sys.stderr.write("[error] install python-concurrent.futures\n")
+    sys.exit(1)
+
 from concurrent.futures import ThreadPoolExecutor, Future
 
 class MorseFuture():


### PR DESCRIPTION
Following the message from Brent Komer brent.komer@gmail.com Fri, Oct 11, 2013 at 6:09 PM on morse-users@laas.fr.

Shall we put `concurrent.futures` in a `requirements.txt` for pypi ?
something like: https://github.com/ross/requests-futures/blob/master/requirements-python-2.7.txt
