### PR TITLE
[ros] remove /base_image addition from camera frame_id

### DIFF
--- a/src/morse/middleware/ros/video_camera.py
+++ b/src/morse/middleware/ros/video_camera.py
@@ -30,7 +30,6 @@ class VideoCameraPublisher(ROSPublisher):
 
         image = Image()
         image.header = self.get_ros_header()
-        image.header.frame_id += '/base_image'
         image.height = self.component_instance.image_height
         image.width = self.component_instance.image_width
         image.encoding = 'rgba8'


### PR DESCRIPTION
I couldn't find any mention of a /base_image postfix to the frame_id of a ROS Image message anywhere, neither can I think of a reason why that would make sense.

Removal of this hardcoded postfix allows to properly set the frame_id of a video camera from the builder script. If someone really needs the '/base_image' addition, it can still be set from the script.
