### PR TITLE
{robot.environment.Environment -> robot.fakerobot.FakeRobot}

### DIFF
--- a/src/morse/builder/robots/morserobots.py
+++ b/src/morse/builder/robots/morserobots.py
@@ -43,7 +43,7 @@ class B21(Robot):
 class FakeRobot(Robot):
     def __init__(self, name=None):
         Robot.__init__(self, name = name) # no Blender model -> a simple Empty will be created
-        self.properties(classpath = "morse.robots.environment.Environment")
+        self.properties(classpath = "morse.robots.fakerobot.FakeRobot")
         self.set_no_collision()
 
 class Hummer(Robot):

--- a/src/morse/robots/fakerobot.py
+++ b/src/morse/robots/fakerobot.py
@@ -2,24 +2,24 @@ import logging; logger = logging.getLogger("morse." + __name__)
 import morse.core.robot
 
 
-class Environment(morse.core.robot.Robot):
+class FakeRobot(morse.core.robot.Robot):
     """
     This is a special case of component in MORSE. Since all sensors or actuators
     must be attached to one robot, it would not normally be possible to use
     "stand-alone" sensors in the environment.
 
     If you need to use a sensor in this way, (*i.e.* for motion capture sensors,
-    or independent cameras) you should add an **environment virtual
+    or independent cameras) you should add an **virtual (fake)
     robot** to the scene, and make it the parent of your stand-alone
     sensors.
 
     This robot has no visual representation, and consists of a single Blender
     Empty. Its only purpose is to provide the base to attach sensors. A single
-    **environment virtual robot** should be the parent of as many
-    sensors as needed.
+    fake robot can be the parent of as many
+    sensors/actuators as needed.
     """
 
-    _name = 'Environment virtual robot'
+    _name = 'Fake virtual robot'
 
     def __init__(self, obj, parent=None):
         # Call the constructor of the parent class


### PR DESCRIPTION
This should be more consistent and fix misleading
'Environment' usage.

Reported by Yoan Mollard.
