### PR TITLE
added 2 services to "Object" to get configs and props from components

### DIFF
--- a/src/morse/core/object.py
+++ b/src/morse/core/object.py
@@ -117,12 +117,8 @@ class Object(AbstractObject):
 
         """
         all_properties = self.fetch_properties()
-        res = {}
 
-        #adds '_properties' as a value to the key "properties"
-        res['properties'] = all_properties
-
-        return res
+        return {'properties': all_properties}
 
 
     @service
@@ -134,18 +130,13 @@ class Object(AbstractObject):
 
         """
         all_properties = self.fetch_properties()
-        res = {}
         tmp = {}
-
         #parses 'all_properties' to get only "key"-"value"-pairs
         #"key" is python_name and "value" is default_value
         for item in all_properties.items():
-            tmp[item[0]] = item[1][0]
+            tmp[item[0]] = item[1][0]   
 
-        #adds parsed "_properties" as a value to the key "configurations"
-        res['configurations'] = tmp
-
-        return res
+        return {'configurations': tmp}
 
 
     def update_properties(self):


### PR DESCRIPTION
For our applications we need to know the configurations of an object once at the start.
So I added 2 new services to the class "Object" in /morse/core/object.py:
- "get_properties" gets the property-field of a component
  example output:

```
id1 SUCCESS {"properties": {"cam_width": [256, "", "(no documentation available yet)", "image_width"], "cam_height": [256, "", "(no documentation available yet)", "image_height"], "cam_focal": [25.0, "", "(no documentation available yet)", "image_focal"], "cam_near": [0.1, "", "(no documentation available yet)", "near_clipping"], "cam_far": [100.0, "", "(no documentation available yet)", "far_clipping"], "Vertical_Flip": [false, "", "(no documentation available yet)", "vertical_flip"]}}
```
- "get_configurations" gets the configurations of a component by parsing the property-field, if the configurations are needed as key-value-pairs
  example output:

```
id SUCCESS {"configurations": [{"Vertical_Flip": false, "cam_focal": 25.0, "cam_width": 256, "cam_far": 100.0, "cam_height": 256, "cam_near": 0.1}]}
```

IMPORTANT:
Do not forget to add a service for your component in your simulation script.
