### PR TITLE
[pocolibs] ability to use DepthCamera as Velodyne

### DIFF
--- a/src/morse/middleware/pocolibs/sensors/velodyne.py
+++ b/src/morse/middleware/pocolibs/sensors/velodyne.py
@@ -17,7 +17,10 @@ class Velodyne3DImage(AbstractDatastream):
 
     def initialize(self):
         name = poster_name(self.component_name, self.kwargs)
-        num_rotation = int(2 * pi / self.component_instance.rotation) + 1
+        num_rotation = 1
+        # if we want to use a static DepthCamera as a Velodyne
+        if 'rotation' in dir(self.component_instance):
+            num_rotation += int(2 * pi / self.component_instance.rotation)
         logger.info("num_rotation %d" % num_rotation)
         self.obj = Velodyne(name, self.component_instance.image_width,
                                      self.component_instance.image_height, num_rotation)


### PR DESCRIPTION
to be used as:

``` python
self.velodyne = DepthCamera()
self.velodyne.translate(x = 0.5, z = 0.35)
self.velodyne.rotate(y = -1.57)
self.velodyne.properties(cam_near = 0.5, cam_far = 50)
self.velodyne.properties(cam_width=128, cam_height=128)
self.append(self.velodyne)
self.velodyne.add_stream('pocolibs',
    'morse.middleware.pocolibs.sensors.velodyne.Velodyne3DImage',
    poster = 'velodyneThreeDImage')
```
