### PR TITLE
[ros] fix get_time to properly use simulated timestamp

### DIFF
--- a/src/morse/middleware/ros/abstract_ros.py
+++ b/src/morse/middleware/ros/abstract_ros.py
@@ -100,9 +100,7 @@ class ROSPublisher(AbstractROS):
         return header
 
     def get_time(self):
-        #not yet :)
-        #return rospy.Time.from_sec(self.data['timestamp'] * 1000.0)
-        return rospy.Time.now()
+        return rospy.Time.from_sec(self.data['timestamp'] / 1000.0)
 
     # Generic publish method
     def publish(self, message):


### PR DESCRIPTION
Any particular reason why this was not enabled yet? (Except that it was multiplied by 1000 instead of divided...?)

Seems to work properly here...

Also is there any specific reason why the timestamp is in milliseconds instead of seconds? Seems that when the timestamp is created, the time in sec is multiplied by 1000 to get ms and everywhere just converted to seconds again later...
