### PR TITLE
[ros] sematic_cam: consider relative option for frame id

### DIFF
--- a/src/morse/middleware/ros/semantic_camera.py
+++ b/src/morse/middleware/ros/semantic_camera.py
@@ -12,11 +12,16 @@ class SemanticCameraPublisher(ROSPublisherTF):
     """
     ros_class = String
 
+    def initialize(self):
+        if not self.component_instance.relative:
+            self.default_frame_id = '/map'
+        ROSPublisherTF.initialize(self)
+
     def default(self, ci='unused'):
         for obj in self.data['visible_objects']:
             # send tf-frame for every object
             self.sendTransform(obj['position'], obj['orientation'],
-                               self.get_time(), str(obj['name']), "/map")
+                               self.get_time(), str(obj['name']), self.frame_id)
         string = String()
         string.data = json.dumps(self.data['visible_objects'], cls=MorseEncoder)
         self.publish(string)
@@ -30,6 +35,11 @@ class SemanticCameraPublisherLisp(ROSPublisherTF):
     """
     ros_class = String
 
+    def initialize(self):
+        if not self.component_instance.relative:
+            self.default_frame_id = '/map'
+        ROSPublisherTF.initialize(self)
+
     def default(self, ci='unused'):
         string = String()
         string.data = "("
@@ -38,7 +48,7 @@ class SemanticCameraPublisherLisp(ROSPublisherTF):
 
             # send tf-frame for every object
             self.sendTransform(obj['position'], obj['orientation'],
-                               self.get_time(), str(obj['name']), "/map")
+                               self.get_time(), str(obj['name']), self.frame_id)
 
             # Build string from name, description, location and orientation in the global world frame
             string.data += "(" + str(obj['name']) + " " + description + " " + \


### PR DESCRIPTION
If the relative option is used the default frame_id is the name of the component, otherwise /map as before
You can also overwrite the frame_id by explicitly specifying it.

fixes #515
