### PR TITLE
Fixed a problem with PTUPosture crashing when multiple PTUs were added.

### DIFF
--- a/src/morse/sensors/ptu_posture.py
+++ b/src/morse/sensors/ptu_posture.py
@@ -58,7 +58,7 @@ class PTUPosture(morse.core.sensor.Sensor):
         logger.info('Component <%s> initialized, runs at %.2f Hz' % (self.bge_object.name, self.frequency))
 
     def _get_ptu(self, obj):
-        if "PanBase" in [c.name for c in obj.children]:
+        if len([c for c in obj.children if "PanBase" in c.name])>0:
             return obj
         elif not obj.parent:
             return None


### PR DESCRIPTION
When multiple PTUs are created with the same parent, MORSE crashed with the following traceback

```
Traceback (most recent call last):
  File "/opt/sara_morse/lib/python3.3/site-packages/morse/blender/calling.py", line 54, in sensor_action
    component_action(contr)
  File "/opt/sara_morse/lib/python3.3/site-packages/morse/blender/calling.py", line 50, in component_action
    cmpt_object.action()
  File "/opt/sara_morse/lib/python3.3/site-packages/morse/core/sensor.py", line 76, in action
    self.default_action()
  File "/opt/sara_morse/lib/python3.3/site-packages/morse/sensors/ptu_posture.py", line 72, in default_action
    if not self._ptu_obj:
AttributeError: 'PTUPosture' object has no attribute '_ptu_obj'
```

The reason was that `c.name` in:

```
   def _get_ptu(self, obj):
        if "PanBase" in [c.name for c in obj.children]:
            return obj
        elif not obj.parent:
            return None
        else:
            return self._get_ptu(obj.parent)
```

was not `PanBase` anymore but rather `PanBase.001`

This commit fixed that problem by looking at any substring of `c.name`
