### PR TITLE
[sensors] Added an 'encoders' level to the velocity sensor

### DIFF
--- a/src/morse/builder/data.py
+++ b/src/morse/builder/data.py
@@ -222,6 +222,11 @@ MORSE_DATASTREAM_DICT = {
             "text": INTERFACE_DEFAULT_OUT,
             "pocolibs": ['morse.middleware.pocolibs.sensors.pom.PomSensorPoster',
                          'morse.middleware.pocolibs.sensors.pom.PomPoster']
+            },
+        "encoders": {
+            "socket": INTERFACE_DEFAULT_OUT,
+            "yarp": INTERFACE_DEFAULT_OUT,
+            "text": INTERFACE_DEFAULT_OUT
             }
         },
     "morse.sensors.pose.Pose": {


### PR DESCRIPTION
This new abstraction level for the velocity sensor that returns encoder ticks instead of linear/angluar speeds

 It assumes a differential drive robot as accordingly adds properties to setup wheel radius, wheel base (and encoder resolution).

The current behaviour (linear + angluar speed) is now the (default) 'standard' level.

This pull-request is not ready for merge. I would like first to get feedback on:
- general usefulness (beyond my own needs :-) )
- is it a good idea to have it as an abstraction level of the velocity sensor? (maybe not, but it fundamentally returns the same information as linear/angular velocities, at a lower level of abstraction...)
- I'm a bit lost between local and world velocities, and I'm not sure I got it correctly (let say, I'm pretty sure I didn't...)
