### PR TITLE
Workaround #558

### DIFF
--- a/src/morse/builder/robots/human.py
+++ b/src/morse/builder/robots/human.py
@@ -70,6 +70,15 @@ class Human(GroundRobot):
 
         self.make_grasper('Hand_Grab.R')
 
+    @property
+    def name(self):
+        return self._bpy_object.name
+
+
+    @name.setter
+    def name(self, value):
+        raise SyntaxError("Human names can not be set explicitely. Use '%s = Human()' syntax instead. See issue #558 for details." % value)
+
     def after_renaming(self):
         if self._blender_filename == 'mocap_human':
             # no need for mocap

--- a/testing/robots/human/multiple_human.py
+++ b/testing/robots/human/multiple_human.py
@@ -43,9 +43,9 @@ class MultipleHumanTest(MorseTestCase):
 
     def test_pose(self):
         with Morse() as morse:
-            p1 = morse.human1.pose.get()
-            p2 = morse.human2.pose.get()
-            p3 = morse.human3.pose.get()
+            p1 = morse.roger.pose.get()
+            p2 = morse.rafael.pose.get()
+            p3 = morse.novak.pose.get()
 
             self.assertAlmostEquals(p1['x'], 5.0, delta=0.01)
             self.assertAlmostEquals(p2['x'], -5.0, delta=0.01)


### PR DESCRIPTION
Issue #558 is due to interaction between 'after_renaming', human model
having several top-level objects (Human, POS_EMPTY, Human_Camera...) and
a builder script with several human instances.

Instead of solving it properly, this fix simply forbid the user to set the
human name via my_instance.name = my_name Instead, my_name = Human() (ie,
automatic renaming) should be used.

A proper fix involve redesigning the human model to have only a single
top-level object.

See details in the issue #558. Closes #558.
