### PR TITLE
[datastream] Allow to pass option configuration to stream manager

### DIFF
--- a/src/morse/blender/main.py
+++ b/src/morse/blender/main.py
@@ -382,7 +382,11 @@ def link_datastreams():
                     break
 
             if not found:
-                datastream_instance = create_instance(datastream_name)
+                try:
+                    kwargs = component_config.stream_manager.get(datastream_name, {})
+                except (AttributeError, NameError) as detail:
+                    kwargs = {}
+                datastream_instance = create_instance(datastream_name, None, kwargs)
                 if datastream_instance is not None:
                     persistantstorage.datastreamDict[datastream_name] = datastream_instance
                     logger.info("\tDatastream interface '%s' created" % datastream_name)

--- a/src/morse/builder/abstractcomponent.py
+++ b/src/morse/builder/abstractcomponent.py
@@ -11,6 +11,7 @@ from morse.helpers.loading import get_class, load_module_attribute
 
 class Configuration(object):
     datastream = {}
+    stream_manager = {}
     modifier = {}
     service = {}
     overlay = {}
@@ -49,6 +50,9 @@ class Configuration(object):
 
     def link_overlay(component,  manager, overlay_cfg, kwargs):
         Configuration.overlay.setdefault(manager, {})[component.name] = [overlay_cfg, kwargs]
+
+    def link_stream_manager_config(manager, kwargs):
+        Configuration.stream_manager.setdefault(manager, {}).update(kwargs)
 
     def has_datastream_configuration(component, stream):
         try:
@@ -101,6 +105,8 @@ class Configuration(object):
         for k, v in Configuration.overlay.items():
             cleaned_overlays[k] = Configuration._remove_entries(v, robot_list)
         cfg.write('overlays = ' + pprint.pformat(cleaned_overlays))
+        cfg.write('\n')
+        cfg.write('stream_manager = ' + pprint.pformat(Configuration.stream_manager))
         cfg.write('\n')
 
 class AbstractComponent(object):

--- a/src/morse/builder/environment.py
+++ b/src/morse/builder/environment.py
@@ -3,6 +3,7 @@ import os
 import pprint
 from morse.core import mathutils
 from morse.builder.morsebuilder import *
+from morse.builder.data import MORSE_DATASTREAM_MODULE
 from morse.builder.abstractcomponent import Configuration
 from morse.core.morse_time import TimeStrategies
 
@@ -520,6 +521,14 @@ class Environment(Component):
         if distribution is not None:
             self.multinode_distribution = distribution
         self._multinode_configured = True
+
+    def configure_stream_manager(self, stream_manager, **kwargs):
+        if stream_manager in MORSE_DATASTREAM_MODULE:
+            stream_manager_classpath = MORSE_DATASTREAM_MODULE[stream_manager]
+        else:
+            stream_manager_classpath = stream_manager
+
+        Configuration.link_stream_manager_config(stream_manager_classpath, kwargs)
 
     def configure_service(self, datastream):
         logger.warning("configure_service is deprecated, use add_service instead")

--- a/src/morse/core/datastream.py
+++ b/src/morse/core/datastream.py
@@ -44,6 +44,9 @@ class DatastreamManager(object):
     # Make this an abstract class
     __metaclass__ = ABCMeta
 
+    def __init__(self, args, kwargs):
+        pass
+
     def __del__(self):
         """ Destructor method. """
         logger.info("Closing datastream interface <%s>." % self.__class__.__name__)

--- a/src/morse/middleware/socket_datastream.py
+++ b/src/morse/middleware/socket_datastream.py
@@ -161,10 +161,10 @@ class SocketReader(SocketServ):
 class SocketDatastreamManager(DatastreamManager):
     """ External communication using sockets. """
 
-    def __init__(self):
+    def __init__(self, args, kwargs):
         """ Initialize the socket connections """
         # Call the constructor of the parent class
-        DatastreamManager.__init__(self)
+        DatastreamManager.__init__(self, args, kwargs)
 
         # port -> MorseSocketServ
         self._server_dict = {}

--- a/src/morse/middleware/yarp_datastream.py
+++ b/src/morse/middleware/yarp_datastream.py
@@ -129,10 +129,10 @@ class YarpReader(YarpPort):
 class YarpDatastreamManager(DatastreamManager):
     """ Handle communication between Blender and YARP."""
 
-    def __init__(self):
+    def __init__(self, args, kwargs):
         """ Initialize the network and connect to the yarp server."""
         # Call the constructor of the parent class
-        DatastreamManager.__init__(self)
+        DatastreamManager.__init__(self, args, kwargs)
 
         yarp.Network.init()
 


### PR DESCRIPTION
It introduces Environment::configure_stream_manager at the builder
level. Information is stored in component_config using the
stream_manager dictionnary, and then passed to the ctor of each
DataStream Manager.

Update the prototype of DatastreamManager.**init** and its son to pass
these additional information
