### PR TITLE
Fix fullscreen issue on retina Mac. fix #383

### DIFF
--- a/bin/morse.in
+++ b/bin/morse.in
@@ -626,9 +626,9 @@ def launch_simulator(scene=None, script=None, node_name=None, geometry=None, scr
                     tmpF.close()
                     os.unlink(tmpF.name)
         logger.info("Executing Blender script: " + script)
-        os.execle(blender_exec, blender_exec, scene, "-y", "-P", script, *other_params)
+        os.execle(blender_exec, blender_exec, scene, "-y", "--no-native-pixels", "-P", script, *other_params)
     else:
-        os.execle(blender_exec, blender_exec, scene, "-y", *other_params)
+        os.execle(blender_exec, blender_exec, scene, "-y", "--no-native-pixels", *other_params)
 
 def do_check(args):
     try:


### PR DESCRIPTION
Blender added a --no-native-pixels to fix scaling issues on high-resolution screens such as the Macbook Retinas.  Using the option shouldn't cause an issue on non-retina displays but I haven't tested it on anything but a MacBook.  I could add it as a command line option to Morse if you think that would be a better option.