### PR TITLE
Fixed a mistake in CMakeLists.txt that fixes issue #587

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ CONFIGURE_FILE(
    )
 INSTALL(PROGRAMS
        ${CMAKE_CURRENT_BINARY_DIR}/bin/morserun.py
-       ${CMAKE_CURRENT_BINARY_DIR}/bin/morse_inspector
+       ${CMAKE_CURRENT_SOURCE_DIR}/bin/morse_inspector
        ${CMAKE_CURRENT_BINARY_DIR}/bin/multinode_server.py
        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
        )


### PR DESCRIPTION
No big deal.
Still some work to do to run MORSE on Windows, but definitively on the good track. Expect a complete fix for the next weeks.
