### PR TITLE
Added missing header data to accelerometer and infrared

### DIFF
--- a/src/morse/middleware/ros/accelerometer.py
+++ b/src/morse/middleware/ros/accelerometer.py
@@ -10,6 +10,7 @@ class TwistPublisher(ROSPublisher):
 
     def default(self, ci='unused'):
         twist = Twist()
+        twist.header = self.get_ros_header()
 
         # Fill twist-msg with the values from the sensor
         twist.linear.x = self.data['velocity'][0]

--- a/src/morse/middleware/ros/infrared.py
+++ b/src/morse/middleware/ros/infrared.py
@@ -8,6 +8,7 @@ class RangePublisher(ROSPublisher):
 
     def default(self, ci='unused'):
         msg = Range()
+        msg.header = self.get_ros_header()
         msg.radiation_type = Range.INFRARED
         msg.field_of_view = 20
         msg.min_range = 0


### PR DESCRIPTION
The header data is required for some use cases like graphical
visualisation in rqt