### PR TITLE
Change basic requirement for Morse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(PYMORSE_SUPPORT "Build and install the Python bindings for MORSE." OFF)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/config/)
 find_package(PkgConfig REQUIRED)
 
-set(PythonInterp_FIND_VERSION 3.2)
+set(PythonInterp_FIND_VERSION 3.3)
 find_package(PythonInterp REQUIRED)
 
 set(PythonLibs_FIND_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")

--- a/bin/morse.in
+++ b/bin/morse.in
@@ -42,9 +42,9 @@ except ImportError as exn:
     sys.exit()
 
 #Blender version must be egal or bigger than...
-MIN_BLENDER_VERSION = "2.62"
+MIN_BLENDER_VERSION = "2.65"
 #Blender version must be smaller than...
-STRICT_MAX_BLENDER_VERSION = "2.75"
+LAST_TESTED_BLENDER_VERSION = "2.74"
 
 #Unix-style path to the MORSE default scene and templates, within the prefix
 DEFAULT_SCENE_PATH = "share/morse/data/morse_default.blend"
@@ -98,11 +98,11 @@ def check_blender_version(blender_path):
 
     logger.info("Checking version of " + blender_path + "... Found v." + version)
 
-    if  version.split('.') >= MIN_BLENDER_VERSION.split('.') and \
-        version.split('.') < STRICT_MAX_BLENDER_VERSION.split('.') :
-        return version
-    else:
+    if version.split('.') < MIN_BLENDER_VERSION.split('.'):
         return False
+    if version.split('.') > LAST_TESTED_BLENDER_VERSION.split('.'):
+        logger.warning("Version %s of Blender is untested but shoudl work" % version)
+    return version
 
 def check_blender_python_version(blender_path):
     """ Creates a small Python script to execute within Blender and get the
@@ -284,7 +284,6 @@ def check_setup():
             else:
                 logger.error("Could not find a correct Blender executable, neither in the " + \
                 "path or in MORSE\nprefix. Blender >= " + MIN_BLENDER_VERSION + \
-                " and < " + STRICT_MAX_BLENDER_VERSION + \
                 " is required to run MORSE.\n" + \
                 "You can alternatively set the $MORSE_BLENDER environment variable " + \
                 "to point to\na specific Blender executable")

--- a/doc/morse/user/faq.rst
+++ b/doc/morse/user/faq.rst
@@ -12,7 +12,7 @@ During installation
     morse/build $ cmake ..
     -- Could NOT find PythonInterp (missing:  PYTHON_EXECUTABLE) 
     CMake Error at CMakeLists.txt:24 (MESSAGE):
-    Can't find python 3.2 on your system
+    Can't find python 3.3 on your system
 
     -- Configuring incomplete, errors occurred!
 
@@ -20,7 +20,7 @@ During installation
   installed in your system.  MORSE should try to find the location of the
   include files and libraries automatically::
 
-    $ cmake -DPYTHON_EXECUTABLE=/usr/local/bin/python3.2 ..
+    $ cmake -DPYTHON_EXECUTABLE=/usr/local/bin/python3.3 ..
 
 
 
@@ -32,10 +32,10 @@ When running morse
     * The $MORSE_BLENDER environment variable doesn't point to a Blender executable! You should fix that! Trying to look for Blender in alternative places...
 
     which: no blender in (/usr/lib/mpich2/bin:/usr/lib/ccache:/usr/local/bin:/bin:/usr/bin:/usr/X11R6/bin)
-    * Could not find a correct Blender executable, neither in the path or in MORSE
-    prefix. Blender >= 2.59 and < 2.62 is required to run MORSE.
-    You can alternatively set the $MORSE_BLENDER environment variable to point to
-    a specific Blender executable
+    * Could not find a correct Blender executable, neither in the path or in
+    MORSE prefix. Blender >= 2.65 is required to run MORSE.  You can
+    alternatively set the $MORSE_BLENDER environment variable to point to a
+    specific Blender executable
 
     * Your environment is not yet correctly setup to run MORSE!
     Please fix it with above information.
@@ -72,16 +72,16 @@ When running morse
 
   - csh::
 
-    $ echo 'setenv PYTHONPATH $PYTHONPATH\:/usr/local/lib/python3.2\:/usr/local/lib/python3.2/site-packages' >> ~/.cshrc
+    $ echo 'setenv PYTHONPATH $PYTHONPATH\:/usr/local/lib/python3.3\:/usr/local/lib/python3.3/site-packages' >> ~/.cshrc
 
   - bash::
 
-    $ echo 'export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.2:/usr/local/lib/python3.2/site-packages' >> ~/.bashrc
+    $ echo 'export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.3:/usr/local/lib/python3.3/site-packages' >> ~/.bashrc
 
   .. warning::
     The name of the installation directory may be different depending on your
     Linux distribution. If you use **Ubuntu** or similar distributions, replace
-    the directory name of ``python3.2/site-packages`` for
+    the directory name of ``python3.3/site-packages`` for
     ``python3/dist-packages``. Make sure to indicate the correct path used in
     your computer for all Python 3 libraries.
 

--- a/doc/morse/user/installation.rst
+++ b/doc/morse/user/installation.rst
@@ -101,27 +101,10 @@ Prerequisites
 +++++++++++++
 
 - ``cmake``
-- Python (3.2 or +)
+- Python (3.3 or +)
 - ``python-dev`` package
-- Blender (>= 2.62) build with Python >= 3.2. You can simply get a binary from
+- Blender (>= 2.65) build with Python >= 3.3. You can simply get a binary from
   `Blender website <http://www.blender.org/download/get-blender/>`_
-
-.. note::
-
-  If you decide to install Python 3.2 by hand, the compilation must be done
-  according to your operating system, to match the Python compiled in
-  Blender:
-  
-  - On **Linux** compile with the ``--with-wide-unicode`` flag. This will
-    provide you with 4-byte Unicode characters (max size: 1114111)
-
-  - On **Mac OS** do not use the ``--with-wide-unicode`` flag. This will
-    provide you with 2-byte Unicode characters (max size: 65535)
- 
-  It the unicode sizes between Python and Blender do not match, you will get
-  errors about undefined symbols with names starting with  PyUnicodeUCS4
-  
-  This is not needed for Python >= 3.3 (Blender >= 2.65) anymore.
 
 
 Middleware-specific instructions

--- a/src/morse/builder/bpymorse.py
+++ b/src/morse/builder/bpymorse.py
@@ -69,8 +69,7 @@ if bpy:
         link_append = bpy.ops.wm.link_append
     collada_import = bpy.ops.wm.collada_import
     add_object = bpy.ops.object.add
-    if bpy.app.version >= (2, 65, 0):
-        add_empty = bpy.ops.object.empty_add
+    add_empty = bpy.ops.object.empty_add
     new_mesh = bpy.data.meshes.new
     new_object = bpy.data.objects.new
     apply_transform = bpy.ops.object.transform_apply
@@ -94,10 +93,7 @@ def create_new_material():
 
 def add_morse_empty(shape = 'ARROWS'):
     """Add MORSE Component Empty object which hlods MORSE logic"""
-    if bpy.app.version >= (2, 65, 0):
-        add_empty(type = shape)
-    else:
-        add_object(type='EMPTY')
+    add_empty(type = shape)
 
 def deselect_all():
     select_all(action='DESELECT')

--- a/src/morse/sensors/camera.py
+++ b/src/morse/sensors/camera.py
@@ -172,25 +172,13 @@ class Camera(morse.core.sensor.Sensor):
         known_ids = set()
         for obj in self._scene.objects:
             if obj.name != '__default__cam__' and id(obj) not in known_ids:
-                if blenderapi.version() < (2, 63, 0):
-                    members = None
-                elif blenderapi.version() < (2, 64, 0):
-                    members = obj.group
-                elif blenderapi.version() < (2, 65, 0):
-                    members = obj.group_parent
-                else:
-                    members = obj.groupMembers
+                members = obj.groupMembers
                 if not members:
                     self._scene_syncable_objects.append(
                             (obj, self._morse_scene.objects[obj.name]))
                     known_ids.add(id(obj))
                 else:
-                    if blenderapi.version() < (2, 64, 0):
-                        main_members = self._morse_scene.objects[obj.name].group
-                    elif blenderapi.version() < (2, 65, 0):
-                        main_members = self._morse_scene.objects[obj.name].group_parent
-                    else:
-                        main_members = self._morse_scene.objects[obj.name].groupMembers
+                    main_members = self._morse_scene.objects[obj.name].groupMembers
                     for i in range(0, len(main_members)):
                         self._scene_syncable_objects.append(
                                 (members[i], main_members[i]))


### PR DESCRIPTION
Rationale (from my morse-dev mail)


|First, I would like to put the minimal requirement from python 3.2 / blender 2.62 to python 3.3 / blender 2.65.

Rationale is basically that:
   - video camera does not work properly in < 2.63
   - depth camera doest not work at all for < 2.65
   - 2.65 is the first release which mandate python 3.3, and I don't think anyone still test the code against python 3.2.

Moreover, I would like to put only a warning when testing the version against MAX_BLENDER_VERSION, and not a "fatal error". Nowadays, the BGE interface seems quite stable, so the strict check is less needed.
