### PR TITLE
[ros] Do not export timestamp in joinstate

### DIFF
--- a/src/morse/middleware/ros/jointstate.py
+++ b/src/morse/middleware/ros/jointstate.py
@@ -11,8 +11,8 @@ class JointStatePublisher(ROSPublisher):
         js.header = self.get_ros_header()
 
         # collect name and positions of jointstates from sensor
-        js.name = self.data.keys()
-        js.position = self.data.values()
+        js.name = self.data.keys()[1:]
+        js.position = self.data.values()[1:]
         # for now leaving out velocity and effort
         #js.velocity = [1, 1, 1, 1, 1, 1, 1]
         #js.effort = [50, 50, 50, 50, 50, 50, 50]


### PR DESCRIPTION
Need testing by a ROS user.

Check the thread  "PR2 - moveit?" thread on morse-users@ for the issue description (basically timestamp is exported as a join).
