### PR TITLE
Improve precision of CoordinateConverter

### DIFF
--- a/.travis.bash
+++ b/.travis.bash
@@ -9,13 +9,28 @@ echo -e "#! /bin/sh\nblender -setaudio NULL \$@" > blender
 chmod +x blender
 export MORSE_BLENDER=$(pwd)/blender
 
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3/dist-packages
+workspace=$(pwd)
+echo "Install virtualenv and numpy for python3.4"
+version=13.1.0
+wget https://github.com/pypa/virtualenv/archive/${version}.tar.gz
+tar xf ${version}.tar.gz
+cd virtualenv-${version}
+export PATH=${PATH}:${HOME}/.local/bin
+python3.4 setup.py install --user # install in ~/.local
+
+virtualenv pyvenv
+source pyvenv/bin/activate
+pip install numpy
+cd ${workspace}
+
+export PYTHONPATH=${workspace}/pyvenv/lib/python3.4/site-packages:$PYTHONPATH
 
 echo "Build and install MORSE"
 mkdir build && cd build
-cmake -DPYTHON_EXECUTABLE=/usr/bin/python3.4 -DPYMORSE_SUPPORT=ON ..
-make
-sudo make install
+cmake -DPYTHON_EXECUTABLE=$(which python3.4) -DPYMORSE_SUPPORT=ON -DCMAKE_INSTALL_PREFIX=${workspace}/pyvenv ..
+make install
+
+export PATH=${PATH}:${workspace}/pyvenv/bin
 
 morse_test() {
     echo "Run $1"

--- a/src/morse/builder/morsebuilder.py
+++ b/src/morse/builder/morsebuilder.py
@@ -34,6 +34,9 @@ def morse_excepthook(*args, **kwargs):
 
 # Uncaught exception quit Blender
 sys.excepthook = morse_excepthook
+# workaround avoid numpy.core.multiarray missmatch ( see #630 )
+sys.path.insert(0, '%s/lib/python%i.%i/site-packages'%(sys.prefix,
+    sys.version_info.major, sys.version_info.minor))
 
 class PassiveObject(AbstractComponent):
     """ Allows to import any Blender object to the scene.
@@ -181,16 +184,16 @@ class Robot(Component):
 
     def make_external(self):
         self._bpy_object.game.properties['Robot_Tag'].name = 'External_Robot_Tag'
-    
+
     def make_ghost(self, alpha=0.3):
         """ Make this robot a ghost
-        
+
         The robot is made transparent, with no collision.
-        
+
         .. note::
              A ghost robot has no influence on other simulated robots
              (no collision, invisible to laser sensors) except for video sensors.
-        
+
         :param alpha: Transparency alpha coefficient (0 for invisible, 1 for opaque, default is 0.3)
         """
         self._make_transparent(self._bpy_object, alpha)
@@ -280,4 +283,3 @@ class WheeledRobot(GroundRobot):
             tmp_x = obj._bpy_object.location[0]
             obj._bpy_object.location[0] = -obj._bpy_object.location[1]
             obj._bpy_object.location[1] = tmp_x
-

--- a/src/morse/helpers/coordinates.py
+++ b/src/morse/helpers/coordinates.py
@@ -6,8 +6,10 @@ import numpy
 class CoordinateConverter:
     """ Allow to convert coordinates from Geodetic to LTP to ECEF-r ... """
     A  = 6378137.0 # WGS-84 Earth semi-major axis
-    B = 6356752.3142 # Second semi-major axis
+    B = 6356752.3142 # WGS-84 Second semi-major axis
     ECC = 8.181919191e-2 # first excentricity
+    F = (A - B) / A # Flatenning
+    R = 6378137.0 # Radius of Earth at equator
     A2 = A**2
     ECC2 = ECC**2
     ECC4 = ECC**4
@@ -95,3 +97,19 @@ class CoordinateConverter:
 
     def geodetic_to_ltp(self, xe):
         return self.ecef_to_ltp(self.geodetic_to_ecef(xe))
+
+    def geodetic_to_geocentric(self, lat, h):
+        """ Convert geodetic latitude to geocentric latitude
+
+        :param: latitude geodetic latitude in degree
+        :param: h height against sea level in meter
+        :return: geocentric latitude in degree
+        """
+        lat_rad = radians(lat)
+        lat_surface = atan((1 - self.F)**2 *tan(lat_rad))
+        sin_lat = sin(lat_rad)
+        cos_lat = cos(lat_rad)
+        s1 = h * sin_lat + self.R * sin(lat_surface)
+        cc = h * cos_lat + self.R * cos(lat_surface)
+        lat_geoc = atan(s1 / cc)
+        return degrees(lat_geoc)

--- a/src/morse/modifiers/ecef.py
+++ b/src/morse/modifiers/ecef.py
@@ -2,7 +2,7 @@ import logging; logger = logging.getLogger("morse." + __name__)
 
 from morse.modifiers.abstract_modifier import AbstractModifier
 from morse.helpers.coordinates import CoordinateConverter
-from morse.core import mathutils
+import numpy
 
 class ECEFmodifier(AbstractModifier):
     """ 
@@ -28,17 +28,18 @@ class ECEFmodifier(AbstractModifier):
 
     def modify(self):
         try:
-            xe = mathutils.Vector(
-                    (
+            xe = numpy.matrix(
+                    [
                     self.data['x'],
                     self.data['y'],
                     self.data['z']
-                    ))
+                    ])
             xt = self.method(xe)
+            logger.info("%s => %s" % (xe, xt))
 
-            self.data['x'] = xt[0]
-            self.data['y'] = xt[1]
-            self.data['z'] = xt[2]
+            self.data['x'] = xt[0, 0]
+            self.data['y'] = xt[0, 1]
+            self.data['z'] = xt[0, 2]
         except KeyError as detail:
             self.key_error(detail)
 

--- a/src/morse/modifiers/geodetic.py
+++ b/src/morse/modifiers/geodetic.py
@@ -3,7 +3,7 @@ import logging; logger = logging.getLogger("morse." + __name__)
 from morse.modifiers.abstract_modifier import AbstractModifier
 from morse.helpers.coordinates import CoordinateConverter
 from math import degrees, radians
-from morse.core import mathutils
+import numpy
 
 class Geodeticmodifier(AbstractModifier):
     """ 
@@ -31,17 +31,19 @@ class CoordinatesToGeodetic(Geodeticmodifier):
     """
     def modify(self):
         try:
-            xe = mathutils.Vector(
-                    (
+            xe = numpy.matrix(
+                    [
                     self.data['x'],
                     self.data['y'],
                     self.data['z']
-                    ))
+                    ])
             xt = self.converter.ltp_to_geodetic(xe)
 
-            self.data['x'] = degrees(xt[0])
-            self.data['y'] = degrees(xt[1])
-            self.data['z'] = xt[2]
+            logger.debug("%s => %s" % (xe, xt))
+
+            self.data['x'] = degrees(xt[0, 0])
+            self.data['y'] = degrees(xt[0, 1])
+            self.data['z'] = xt[0, 2]
         except KeyError as detail:
             self.key_error(detail)
 
@@ -50,16 +52,18 @@ class CoordinatesFromGeodetic(Geodeticmodifier):
     """
     def modify(self):
         try:
-            xe = mathutils.Vector(
-                    (
+            xe = numpy.matrix(
+                    [
                     radians(self.data['x']),
                     radians(self.data['y']),
                     self.data['z']
-                    ))
+                    ])
             xt = self.converter.geodetic_to_ltp(xe)
 
-            self.data['x'] = xt[0]
-            self.data['y'] = xt[1]
-            self.data['z'] = xt[2]
+            logger.debug("%s => %s" % (xe, xt))
+
+            self.data['x'] = xt[0, 0]
+            self.data['y'] = xt[0, 1]
+            self.data['z'] = xt[0, 2]
         except KeyError as detail:
             self.key_error(detail)

--- a/src/morse/sensors/gps.py
+++ b/src/morse/sensors/gps.py
@@ -5,6 +5,7 @@ import math, time
 from morse.core import mathutils
 from morse.core import blenderapi
 from morse.helpers.coordinates import CoordinateConverter
+import numpy
 
 class GPS(morse.core.sensor.Sensor):
     """
@@ -234,13 +235,13 @@ class RawGPS(GPS):
         self.pvz = self.v[2]
 
         #current position
-        xt = mathutils.Vector(self.position_3d.translation)
+        xt = numpy.matrix(self.position_3d.translation)
         gps_coords = self.coord_converter.ltp_to_geodetic(xt)
 
         #compose message as close as possible to a GPS-standardprotocol
-        self.local_data['longitude'] = math.degrees(gps_coords[0])
-        self.local_data['latitude'] = math.degrees(gps_coords[1])
-        self.local_data['altitude'] = gps_coords[2]
+        self.local_data['longitude'] = math.degrees(gps_coords[0, 0])
+        self.local_data['latitude'] = math.degrees(gps_coords[0, 1])
+        self.local_data['altitude'] = gps_coords[0, 2]
         self.local_data['velocity'] = self.v
 
 class ExtendedGPS(RawGPS):

--- a/src/morse/sensors/magnetometer.py
+++ b/src/morse/sensors/magnetometer.py
@@ -9,6 +9,8 @@ from math import degrees
 import datetime
 import os
 
+import numpy
+
 def _decimal_date(date):
     bisextile = (date.year % 4 == 0 and date.year % 100 != 0) or (date.year % 400 == 0)
     days_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
@@ -30,12 +32,12 @@ class MagnetoDriver(object):
             self._date = _decimal_date(datetime.date.today())
 
     def compute(self, pose):
-        pos = pose.translation
+        pos = numpy.matrix(pose.translation)
         pos_lla = self._coord_conv.ltp_to_geodetic(pos)
         (decl, incl, f, h, x, y, z) = self._mag.compute(
-                                 degrees(pos_lla[0]),
-                                 degrees(pos_lla[1]),
-                                 pos_lla[2] / 1000.0, self._date)
+                                 degrees(pos_lla[0, 0]),
+                                 degrees(pos_lla[0, 1]),
+                                 pos_lla[0, 2] / 1000.0, self._date)
         mag_field = mathutils.Vector((x, y, z))
         return mag_field * pose.rotation_matrix
 

--- a/testing/base/ecef_testing.py
+++ b/testing/base/ecef_testing.py
@@ -65,8 +65,8 @@ class ECEFModifierTest(MorseTestCase):
             # Z = 0.1 : pose of the ATRV's center relative to the world
             self.assertAlmostEqual(pos['z'], 0.1, delta=precision)
 
-            self.assertAlmostEqual(pos_mod['x'], 4617522.5, delta=precision)
-            self.assertAlmostEqual(pos_mod['y'], 4397221.0, delta=precision)
+            self.assertAlmostEqual(pos_mod['x'], 4617522.748, delta=precision)
+            self.assertAlmostEqual(pos_mod['y'], 4397221.061, delta=precision)
             self.assertAlmostEqual(pos_mod['z'], 158481.296875, delta=precision)
 
             teleport_stream.publish({'x' : 100.0, 'y' : 200.0, 'z' : 50.0, 'yaw' : 0.0, 'pitch' : 0.0, 'roll' : 0.0})
@@ -78,24 +78,26 @@ class ECEFModifierTest(MorseTestCase):
             self.assertAlmostEqual(pos['x'], 100.0, delta=precision)
             self.assertAlmostEqual(pos['y'], 200.0, delta=precision)
             self.assertAlmostEqual(pos['z'], 50.0, delta=precision)
-            self.assertAlmostEqual(pos_mod['x'], 4617493.0, delta=precision)
-            self.assertAlmostEqual(pos_mod['y'], 4397317.5, delta=precision)
-            self.assertAlmostEqual(pos_mod['z'], 158674.484375, delta=precision)
+
+            self.assertAlmostEqual(pos_mod['x'], 4617493.329 , delta=precision)
+            self.assertAlmostEqual(pos_mod['y'], 4397317.326, delta=precision)
+            self.assertAlmostEqual(pos_mod['z'], 158674.47893, delta=precision)
 
             morse.deactivate('robot.teleport')
-            teleport_mod_stream.publish({'x': 4617522.5, 'y': 4397221.0, 'z':158481.296875,  'yaw' : 0.0, 'pitch' : 0.0, 'roll': 0.0})
+            teleport_mod_stream.publish({'x': 4617522.748, 'y': 4397221.061, 'z':158481.296875,  'yaw' : 0.0, 'pitch' : 0.0, 'roll': 0.0})
             morse.sleep(0.03)
 
             pos = gps_stream.get()
             pos_mod = gps_mod_stream.last()
 
-            self.assertAlmostEqual(pos['x'], 10.0, delta=0.15)
-            self.assertAlmostEqual(pos['y'], 8.0, delta=0.15)
-            self.assertAlmostEqual(pos['z'], 0.1, delta=0.15)
+            self.assertAlmostEqual(pos['x'], 10.0, delta=precision)
+            self.assertAlmostEqual(pos['y'], 8.0, delta=precision)
+            self.assertAlmostEqual(pos['z'], 0.1, delta=precision)
 
-            self.assertAlmostEqual(pos_mod['x'], 4617522.5, delta=precision)
-            self.assertAlmostEqual(pos_mod['y'], 4397221.0, delta=precision)
+            self.assertAlmostEqual(pos_mod['x'], 4617522.748, delta=precision)
+            self.assertAlmostEqual(pos_mod['y'], 4397221.061, delta=precision)
             self.assertAlmostEqual(pos_mod['z'], 158481.296875, delta=precision)
+
 
 
 ########################## Run these tests ##########################

--- a/testing/base/geodetic_testing.py
+++ b/testing/base/geodetic_testing.py
@@ -66,9 +66,9 @@ class GeodeticModifierTest(MorseTestCase):
             # Z = 0.1 : pose of the ATRV's center relative to the world
             self.assertAlmostEqual(pos['z'], 0.1, delta=precision)
 
-            self.assertAlmostEqual(pos_mod['x'], 43.6000894, delta=geodetic_precision)
+            self.assertAlmostEqual(pos_mod['x'], 43.6000883, delta=geodetic_precision)
             self.assertAlmostEqual(pos_mod['y'], 1.433372470, delta=geodetic_precision)
-            self.assertAlmostEqual(pos_mod['z'], 134.878, delta=precision)
+            self.assertAlmostEqual(pos_mod['z'], 135.1000, delta=precision)
 
             teleport_stream.publish({'x' : 100.0, 'y' : 200.0, 'z' : 50.0, 'yaw' : 0.0, 'pitch' : 0.0, 'roll' : 0.0})
             morse.sleep(0.01)
@@ -79,24 +79,24 @@ class GeodeticModifierTest(MorseTestCase):
             self.assertAlmostEqual(pos['x'], 100.0, delta=precision)
             self.assertAlmostEqual(pos['y'], 200.0, delta=precision)
             self.assertAlmostEqual(pos['z'], 50.0, delta=precision)
-            self.assertAlmostEqual(pos_mod['x'], 43.6009, delta=geodetic_precision)
-            self.assertAlmostEqual(pos_mod['y'], 1.43510876, delta=geodetic_precision)
-            self.assertAlmostEqual(pos_mod['z'], 184.885, delta=precision)
+            self.assertAlmostEqual(pos_mod['x'], 43.6008970, delta=geodetic_precision)
+            self.assertAlmostEqual(pos_mod['y'], 1.43510869, delta=geodetic_precision)
+            self.assertAlmostEqual(pos_mod['z'], 185.0039, delta=precision)
 
             morse.deactivate('robot.teleport')
-            teleport_mod_stream.publish({'x': 43.6000894, 'y': 1.433372470, 'z': 134.878,  'yaw' : 0.0, 'pitch' : 0.0, 'roll': 0.0})
+            teleport_mod_stream.publish({'x': 43.6000883, 'y': 1.433372470, 'z': 135.1000,  'yaw' : 0.0, 'pitch' : 0.0, 'roll': 0.0})
             morse.sleep(0.03)
 
             pos = gps_stream.get()
             pos_mod = gps_mod_stream.last()
 
-            self.assertAlmostEqual(pos['x'], 10.0, delta=0.15)
-            self.assertAlmostEqual(pos['y'], 8.0, delta=0.15)
-            self.assertAlmostEqual(pos['z'], 0.1, delta=0.15)
+            self.assertAlmostEqual(pos['x'], 10.0, delta=precision)
+            self.assertAlmostEqual(pos['y'], 8.0, delta=precision)
+            self.assertAlmostEqual(pos['z'], 0.1, delta=precision)
 
-            self.assertAlmostEqual(pos_mod['x'], 43.6000894, delta=geodetic_precision)
+            self.assertAlmostEqual(pos_mod['x'], 43.6000883, delta=geodetic_precision)
             self.assertAlmostEqual(pos_mod['y'], 1.433372470, delta=geodetic_precision)
-            self.assertAlmostEqual(pos_mod['z'], 134.878, delta=precision)
+            self.assertAlmostEqual(pos_mod['z'], 135.1000, delta=precision)
 
 ########################## Run these tests ##########################
 if __name__ == "__main__":

--- a/testing/base/gps_testing.py
+++ b/testing/base/gps_testing.py
@@ -64,7 +64,7 @@ class GPSTest(MorseTestCase):
             # no regression134.88
             self.assertAlmostEqual(pos_raw['latitude'], 1.4333, delta=precision_deg)
             self.assertAlmostEqual(pos_raw['longitude'], 43.6, delta=precision_deg)
-            self.assertAlmostEqual(pos_raw['altitude'], 134.88, delta=precision)
+            self.assertAlmostEqual(pos_raw['altitude'], 135.1, delta=precision)
 
             teleport_stream.publish({'x' : 100.0, 'y' : 200.0, 'z' : 50.0, 'yaw' : 0.0, 'pitch' : 0.0, 'roll' : 0.0})
             morse.sleep(0.01)
@@ -81,7 +81,7 @@ class GPSTest(MorseTestCase):
             # no regression
             self.assertAlmostEqual(pos_raw['latitude'], 1.4351, delta=precision_deg)
             self.assertAlmostEqual(pos_raw['longitude'], 43.6009, delta=precision_deg)
-            self.assertAlmostEqual(pos_raw['altitude'], 184.88, delta=precision)
+            self.assertAlmostEqual(pos_raw['altitude'], 185.003, delta=precision)
 
 ########################## Run these tests ##########################
 if __name__ == "__main__":


### PR DESCRIPTION
While trying to integrate jsbsim with Morse, I notice some issue in the precision in the conversion between LLH and LTP. After investigation, the problem comes from the use of mathutils stuff, which use simple precision "float". So I reimplement it using numpy (which use double precision).

If we merge that, it implies that Morse now depends on Numpy. In my opinion, it is not a big issue, as it is packaged by all distributions, and in the worst case, is already distributed by Blender. 
