### PR TITLE
do not publish timestamp as a joint

### DIFF
--- a/src/morse/middleware/ros/jointstate.py
+++ b/src/morse/middleware/ros/jointstate.py
@@ -29,6 +29,7 @@ class JointStatePR2Publisher(ROSPublisher):
         js.header = self.get_ros_header()
 
         joints =  fill_missing_pr2_joints(self.data)
+        del joints['timestamp']
         js.name = joints.keys()
         js.position = joints.values()
 

--- a/src/morse/middleware/ros/jointtrajectorycontrollers.py
+++ b/src/morse/middleware/ros/jointtrajectorycontrollers.py
@@ -12,10 +12,13 @@ class JointTrajectoryControllerStatePublisher(ROSPublisher):
         js = JointTrajectoryControllerState()
         js.header = self.get_ros_header()
 
-        js.joint_names = self.data.keys()
-        js.actual.positions = self.data.values()
+        # timestamp is not a joint
+        joints = dict(self.data)
+        del joints['timestamp']
+        js.joint_names = joints.keys()
+        js.actual.positions = joints.values()
 
-        js.actual.velocities = [0.0] * len(self.data)
-        js.actual.accelerations = [0.0] * len(self.data)
+        js.actual.velocities = [0.0] * len(joints)
+        js.actual.accelerations = [0.0] * len(joints)
 
         self.publish(js)


### PR DESCRIPTION
in /jointstate and [l/r]_arm_controller/state
for pr2
applied to ROS middleware