### PR TITLE
Direction datastream

### DIFF
--- a/bindings/pymorse/src/pymorse/pymorse.py
+++ b/bindings/pymorse/src/pymorse/pymorse.py
@@ -329,7 +329,10 @@ class Component(object):
         self.stream = None
         self._init = False
         self._port = port
-        self._stream_dir = stream
+        if not stream:
+            self._stream_dir = set()
+        else:
+            self._stream_dir = set([s[1] for s in stream])
 
         for service in services:
             logger.debug("Adding service %s to component %s" % (service, self.name))
@@ -342,9 +345,9 @@ class Component(object):
         if self._port:
             self.stream = StreamJSON(self._morse.host, self._port)
 
-            if self._stream_dir == 'IN':
+            if 'IN' in self._stream_dir:
                 self.publish = self.stream.publish
-            elif self._stream_dir == 'OUT':
+            if 'OUT' in self._stream_dir:
                 self.get = self.stream.get
                 self.last = self.stream.last
                 self.subscribe = self.stream.subscribe
@@ -523,7 +526,7 @@ class Morse(object):
                 setattr(self, name + "s", list_robots)
 
     def _add_component(self, robot, fqn, details):
-        stream = details.get('stream', None)
+        stream = details.get('stream_interfaces', None)
         port = None
         if stream:
             try:

--- a/src/morse/actuators/armature.py
+++ b/src/morse/actuators/armature.py
@@ -5,7 +5,7 @@ from morse.core.blenderapi import mathutils
 from collections import OrderedDict
 import morse.core.actuator
 from morse.core import status
-from morse.core.blenderapi import version, CONSTRAINT_TYPE_KINEMATIC, CONSTRAINT_IK_DISTANCE
+from morse.core import blenderapi
 from morse.core.services import service, async_service, interruptible
 from morse.core.exceptions import MorseRPCInvokationError
 from morse.core.morse_time import time_isafter
@@ -114,8 +114,8 @@ class Armature(morse.core.actuator.Actuator):
             self.local_data[channel.name] = 0.0
 
         self._ik_targets = {c.target: c for c in armature.constraints \
-                            if c.type == CONSTRAINT_TYPE_KINEMATIC and \
-                               c.ik_type == CONSTRAINT_IK_DISTANCE}
+                            if c.type == blenderapi.CONSTRAINT_TYPE_KINEMATIC and \
+                               c.ik_type == blenderapi.CONSTRAINT_IK_DISTANCE}
 
         # Initially desactivate all IK constraints
         for c in self._ik_targets.values():
@@ -161,7 +161,7 @@ class Armature(morse.core.actuator.Actuator):
     def _suspend_ik_targets(self):
         for c in self._ik_targets.values():
             #Bug in Blender! cf http://developer.blender.org/T37892
-            if version() < (2, 70, 0):
+            if blenderapi.version() < (2, 70, 0):
                 if not c.active:
                     logger.info("Stop tracking IK target <%s>" % c.target.name)
                     c.active = False
@@ -174,7 +174,7 @@ class Armature(morse.core.actuator.Actuator):
     def _restore_ik_targets(self):
         for c in self._ik_targets.values():
             #Bug in Blender! cf http://developer.blender.org/T37892
-            if version() < (2, 70, 0):
+            if blenderapi.version() < (2, 70, 0):
                 if c.active:
                     c.active = True
                     logger.info("Tracking IK target <%s>" % c.target.name)

--- a/src/morse/blender/main.py
+++ b/src/morse/blender/main.py
@@ -334,18 +334,7 @@ def link_datastreams():
         if isinstance (datastream_list[0], str):
             datastream_list = [datastream_list]
 
-        # What is the direction of our stream?
-        # -> for Sensors, they *publish*,
-        # -> for Actuator, they *read*
-        if isinstance(instance, Sensor):
-            direction = OUT
-        elif isinstance(instance, Actuator):
-            direction = IN
-        else:
-            assert False
-
-        persistantstorage.datastreams[component_name] = (direction,
-                                     [d[0] for d in datastream_list])
+        persistantstorage.datastreams[component_name] = datastream_list
 
         # Register all datastream's in the list
         for datastream_data in datastream_list:

--- a/src/morse/blender/main.py
+++ b/src/morse/blender/main.py
@@ -328,12 +328,6 @@ def link_datastreams():
             # Skip the configuration of this component
             continue
 
-        # If the list contains only strings, insert the list inside another one.
-        # This is done for backwards compatibility with the previous
-        #  syntax that allowed only one middleware per component
-        if isinstance (datastream_list[0], str):
-            datastream_list = [datastream_list]
-
         persistantstorage.datastreams[component_name] = datastream_list
 
         # Register all datastream's in the list

--- a/src/morse/blender/main.py
+++ b/src/morse/blender/main.py
@@ -476,11 +476,12 @@ def add_modifiers():
 
         for mod_data in mod_list:
             modifier_name = mod_data[0]
+            direction = mod_data[1]
             logger.info("Component: '%s' operated by '%s'" %
                         (component_name, modifier_name))
             # Make the modifier object take note of the component
             modifier_instance = register_modifier(modifier_name, instance,
-                                                  mod_data[1])
+                                                  direction, mod_data[2])
             if not modifier_instance:
                 return False
             persistantstorage.modifierDict[modifier_name] = modifier_instance

--- a/src/morse/core/datastream.py
+++ b/src/morse/core/datastream.py
@@ -13,22 +13,15 @@ from morse.middleware import AbstractDatastream
 from morse.helpers.loading import create_instance
 
 
-def register_datastream(classpath, component, args):
+def register_datastream(classpath, component, direction, args):
     datastream = create_instance(classpath, component, args)
     # Check that datastream implements AbstractDatastream
     if not isinstance(datastream, AbstractDatastream):
         logger.warning("%s should implement morse.middleware.AbstractDatastream"%classpath)
-    # Determine weither to store the function in input or output list,
-    #   what is the direction of our stream?
-    if isinstance(component, Sensor):
-        # -> for Sensors, they *publish*,
+    if direction == 'OUT':
         component.output_functions.append(datastream.default)
-    elif isinstance(component, Actuator):
-        # -> for Actuator, they *read*
-        component.input_functions.append(datastream.default)
     else:
-        logger.error("The component is not an instance of Sensor or Actuator")
-        return None
+        component.input_functions.append(datastream.default)
     # from morse.core.abstractobject.AbstractObject
     component.del_functions.append(datastream.finalize)
 
@@ -54,12 +47,14 @@ class DatastreamManager(object):
 
     def register_component(self, component_name, component_instance, mw_data):
         datastream_classpath = mw_data[1] # aka. function name
+        direction = mw_data[2]
         datastream_args = None
-        if len(mw_data) > 2:
-            datastream_args = mw_data[2] # aka. kwargs, a dictonnary of args
+        if len(mw_data) > 3:
+            datastream_args = mw_data[3] # aka. kwargs, a dictonnary of args
 
         # Create a socket server for this component
         return register_datastream(datastream_classpath, component_instance,
+                                                         direction,
                                                          datastream_args)
 
 

--- a/src/morse/core/external_object.py
+++ b/src/morse/core/external_object.py
@@ -1,6 +1,7 @@
 import logging; logger = logging.getLogger("morse." + __name__)
 from abc import ABCMeta, abstractmethod
 import morse.core.object
+from morse.helpers.components import add_data
 
 class ExternalObject(morse.core.object.Object):
     """ Basic Class for all External Object
@@ -64,7 +65,14 @@ class ExternalObject(morse.core.object.Object):
             function(self)
 
 class ExternalSensor(ExternalObject):
-    pass
+    add_data('timestamp', 0.0, 'float', 
+             'number of seconds in simulated time')
+
+    def action(self):
+        self.local_data['timestamp'] = self.robot_parent.gettime()
+
+        ExternalObject.action(self)
+
 
 class ExternalActuator(ExternalObject):
     pass

--- a/src/morse/core/external_object.py
+++ b/src/morse/core/external_object.py
@@ -1,0 +1,70 @@
+import logging; logger = logging.getLogger("morse." + __name__)
+from abc import ABCMeta, abstractmethod
+import morse.core.object
+
+class ExternalObject(morse.core.object.Object):
+    """ Basic Class for all External Object
+
+    Provides common attributes. """
+
+    # Make this an abstract class
+    __metaclass__ = ABCMeta
+
+    def __init__ (self, obj, parent=None):
+        """ Constructor method. """
+        # Call the constructor of the parent class
+        morse.core.object.Object.__init__(self, obj, parent)
+
+        # Define lists of dynamically added functions
+        self.input_functions = []
+        self.output_functions = []
+        self.input_modifiers = []
+        self.output_modifiers = []
+
+    def finalize(self):
+        self._active = False
+        morse.core.object.Object.finalize(self)
+        del self.input_functions[:]
+        del self.output_functions[:]
+        del self.input_modifiers[:]
+        del self.output_modifiers[:]
+
+
+    def action(self):
+        """ Call the action functions that have been added to the list. """
+        # Do nothing if this component has been deactivated
+        if not self._active:
+            return
+
+        # Update the component's position in the world
+        self.position_3d.update(self.bge_object)
+
+        received = False
+        status = False
+
+        # First the input functions
+        for function in self.input_functions:
+            status = function(self)
+            received = received or status
+
+        if received:
+            # Data modification functions
+            for function in self.input_modifiers:
+                function()
+
+        # Call the regular action function of the component
+        self.default_action()
+
+        # Data modification functions
+        for function in self.output_modifiers:
+            function()
+
+        # Lastly output functions
+        for function in self.output_functions:
+            function(self)
+
+class ExternalSensor(ExternalObject):
+    pass
+
+class ExternalActuator(ExternalObject):
+    pass

--- a/src/morse/core/modifier.py
+++ b/src/morse/core/modifier.py
@@ -6,7 +6,7 @@ from morse.core.sensor import Sensor
 from morse.core.actuator import Actuator
 from morse.helpers.loading import create_instance
 
-def register_modifier(classpath, component, args):
+def register_modifier(classpath, component, direction, args):
     modifier = create_instance(classpath, component, args)
     if not modifier:
         logger.error("INITIALIZATION ERROR: Modifier '%s' module could not be "
@@ -23,15 +23,13 @@ def register_modifier(classpath, component, args):
 
     # Determine weither to store the function in input or output list,
     #   what is the direction of our stream?
-    if isinstance(component, Sensor):
-        # -> for Sensors, they *publish*,
+    if direction is 'OUT':
         component.output_modifiers.append(modifier.modify)
-    elif isinstance(component, Actuator):
-        # -> for Actuator, they *read*
+    elif direction is 'IN':
         component.input_modifiers.append(modifier.modify)
     else:
-        logger.error("Component %s is not an instance of Sensor or Actuator" %
-                     component.__class__)
+        logger.error("Direction '%s' for '%s'is not 'IN' or 'OUT'",
+                     direction, component.__class__)
         return None
 
     return modifier

--- a/src/morse/middleware/hla/abstract_hla.py
+++ b/src/morse/middleware/hla/abstract_hla.py
@@ -10,8 +10,16 @@ class AbstractHLAOutput(AbstractDatastream):
     def register_object(self, handle):
         self._obj = self.amb.register_object(handle, self._hla_name)
 
+    def publish_attributes(self, obj_handle, attr_handles):
+        self.amb.publish_attributes(self._hla_name, obj_handle, attr_handles)
+
     def update_attribute(self, to_send):
-        self.amb.update_attribute(self._obj, to_send)
+        if not self._obj:
+            self._obj = self.amb.get_object(self._hla_name)
+        if not self._obj:
+            logger.warning("Cannot find reference for object %s : don't update its attribute" % self._hla_name)
+        else:
+            self.amb.update_attribute(self._obj, to_send)
 
     def finalize(self):
         self.amb.delete_object(self._hla_name)

--- a/src/morse/middleware/hla_datastream.py
+++ b/src/morse/middleware/hla_datastream.py
@@ -305,7 +305,7 @@ class HLADatastreamManager(DatastreamManager):
         """ Open the port used to communicate by the specified component.
         """
 
-        mw_data[2]['__hla_node'] = self.node
+        mw_data[3]['__hla_node'] = self.node
 
         DatastreamManager.register_component(self, component_name,
                                                    component_instance, mw_data)

--- a/src/morse/middleware/socket_datastream.py
+++ b/src/morse/middleware/socket_datastream.py
@@ -262,9 +262,11 @@ class SocketDatastreamManager(DatastreamManager):
         register_success = False
         must_inc_base_port = False
 
-        if not 'port' in mw_data[2]:
+        kwargs = mw_data[3]
+
+        if not 'port' in kwargs:
             must_inc_base_port = True
-            mw_data[2]['port'] = self._base_port
+            kwargs['port'] = self._base_port
 
         while not register_success:
             try:
@@ -274,14 +276,14 @@ class SocketDatastreamManager(DatastreamManager):
                 register_success = True
             except socket.error as error_info:
                 if error_info.errno ==  errno.EADDRINUSE:
-                    mw_data[2]['port'] += 1
+                    kwargs['port'] += 1
                     if must_inc_base_port:
                         self._base_port += 1
                 else:
                     raise
 
-        self._server_dict[mw_data[2]['port']] = serv
-        self._component_nameservice[component_name] = mw_data[2]['port']
+        self._server_dict[kwargs['port']] = serv
+        self._component_nameservice[component_name] = kwargs['port']
         if must_inc_base_port:
             self._base_port += 1
 

--- a/src/morse/services/supervision_services.py
+++ b/src/morse/services/supervision_services.py
@@ -154,9 +154,8 @@ class Supervision(AbstractObject):
                 cmpt["service_interfaces"] = services_iface[c.name()]
 
             if c.name() in simu.datastreams:
-                stream = simu.datastreams[c.name()]
-                cmpt["stream"] = stream[0]
-                cmpt["stream_interfaces"] = stream[1]
+                streams = simu.datastreams[c.name()]
+                cmpt["stream_interfaces"] = [(stream[0], stream[2]) for stream in streams]
 
             return cmpt
 


### PR DESCRIPTION
Please consider the following patch request.

The idea is to be able to pass explicitly the direction of datastream and modifier at the builder level. If it is not passed explicitly, we use the default direction (i.e. out for sensor and in for actuator). 

Why do we need that ? In a near future, I would like to develop 'ExternalSensor' / 'ExternalActuator' (naming is not definitive), i.e. actuator which gets input from 'a robotic architecture' (such as ROS, YARP, ...) and output data for a specialized simulator (using 'hla', 'socket' or 'whatever' protocol) (and the inverse thing for sensor). So we need basically both input and output for them. For normal Sensor / Actuator, this set of commits should not change anything.

Please comment.