### PR TITLE
Fixing weard behavior when a wheeled robot start moving:

### DIFF
--- a/src/morse/core/wheeled_robot.py
+++ b/src/morse/core/wheeled_robot.py
@@ -279,7 +279,7 @@ class MorsePhysicsRobot(PhysicsWheelRobot):
             # object
             if self._stopped:
                 self.bge_object.applyImpulse(
-                   self.bge_object.position, (0.0, 0.1, -0.000001))
+                   self.bge_object.position, (0.0, 0.0, 0.000001))
 
             # no longer stopped
             self._stopped = False


### PR DESCRIPTION
Waking up a wheeled robot should not induce any rotation.
I removed the rotation value in the impulse that wake up
the physical object.