### PR TITLE
Port morse-theme to Sphinx 1.3

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -22,6 +22,9 @@ sys.path.append('@CMAKE_CURRENT_SOURCE_DIR@/doc/exts')
 
 # -- General configuration -----------------------------------------------------
 
+# If your documentation needs a minimal Sphinx version, state it here.
+needs_sphinx = '1.3'
+
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 

--- a/doc/morse-theme/templates/layout.html
+++ b/doc/morse-theme/templates/layout.html
@@ -1,7 +1,7 @@
 {#
  MORSE Sphinx template
 #}
-{% extends "default/layout.html" %}
+{% extends "classic/layout.html" %}
 
 {% block rootrellink %}
     <li><a href="{{ pathto(master_doc) }}">{{ project }}</a>{{ reldelim1 }}

--- a/doc/morse-theme/theme.conf
+++ b/doc/morse-theme/theme.conf
@@ -1,5 +1,5 @@
 [theme]
-inherit = default 
+inherit = classic
 stylesheet = sphinx-minimal.css
 
 [options]


### PR DESCRIPTION
In Sphinx 1.3, `default` theme was renamed to `classic`, so `default/layout.html` no longer exists.