### PR TITLE
[bin] allow to override the python missmatch crash

### DIFF
--- a/bin/morse.in
+++ b/bin/morse.in
@@ -302,7 +302,8 @@ def check_setup():
                    " but MORSE has been compiled for Python " + \
                    our_python_version + "! Check your MORSE build configuration"
                    " or the selected Blender version.")
-            raise MorseError("Bad Python version")
+            if 'MORSE_SILENT_PYTHON_CHECK' not in os.environ:
+                raise MorseError("Bad Python version")
         else:
             logger.info("Blender and Morse are using Python " + \
             python_version + ". Alright.")

--- a/doc/man/morse_man_page.rst
+++ b/doc/man/morse_man_page.rst
@@ -96,6 +96,10 @@ Environment
 			variable to determine the name of the node. If it does not exist,
 			rely on the name of the host.
 
+:MORSE_SILENT_PYTHON_CHECK:
+			Do not restrict matching system vs. Blender Python version. Use at
+			your own risk.
+
 Morse relying on Python to execute itself, the run of Morse is influenced by
 all Python variables, in particular **PYTHONPATH**. See :manpage:`python(1)` for
 details.

--- a/src/morse/services/supervision_services.py
+++ b/src/morse/services/supervision_services.py
@@ -275,6 +275,24 @@ class Supervision(AbstractObject):
         return position
 
     @service
+    def get_camarafp_position(self):
+        """ Get the CamaraFP (MORSE' environment camera) world position. [x, y, z]
+
+        :returns: The camera's world position. [x, y, z].
+        """
+        blender_object = get_obj_by_name('CameraFP')
+        return blender_object.worldPosition
+
+    @service
+    def get_camarafp_transform(self):
+        """ Get the CamaraFP (MORSE' environment camera) world space transform matrix.
+
+        :returns: The camera's world space transform matrix. 4x4 Matrix [[float]]
+        """
+        blender_object = get_obj_by_name('CameraFP')
+        return blender_object.worldTransform
+
+    @service
     def set_camarafp_transform(self, transform):
         """ Set the CamaraFP (MORSE' environment camera) world space transform matrix.
 


### PR DESCRIPTION
To avoid the system vs. Blender Python version missmatch crash, just:
```
export MORSE_SILENT_PYTHON_CHECK=1
```