### PR TITLE
Filter out Blender objects starting with _ when importing

### DIFF
--- a/doc/morse/dev/adding_component.rst
+++ b/doc/morse/dev/adding_component.rst
@@ -282,6 +282,7 @@ An user would configure this sensor in a script that way:
     ...
 
 
+.. _blender-advices:
 
 The 'Blender' part
 ------------------
@@ -293,12 +294,19 @@ The 'Blender' part
   * ``x`` points forward, ``z`` points up.
   * You can of course import meshes in Blender. Just check the scale and orientation.
   * Do not forget that your mesh will be used in a real-time 3D engine: keep
-    the number of polygons low ( > 500 for a single model is probably already
-    too much. Check the ``decimate`` tool in Blender to simplify your model if
-    needed).
+    the number of polygons low (check the ``decimate`` tool in Blender to
+    simplify your model if needed).
   * Do not forget the :doc:`bounding boxes<../user/tips/bounding_boxes>`.
   * If your sensor/actuator has a kinematic structure (not a single rigid part),
-    use Blender's armatures to model it precisely.
+    use Blender's armatures to model it precisely (see below the note on
+    armatures)..
+
+.. note::
+
+    You may have some elements in your Blender scene (like lights or a physical
+    floor to test physics) that you would like to keep while creating the model,
+    but you do not want MORSE to import them in the final simulation. Simply
+    prefix their name with ``_`` in Blender: MORSE will ignore those.
 
 - Save the model in ``$MORSE_ROOT/data/<sensors|actuators>/``
 

--- a/doc/morse/dev/adding_robot.rst
+++ b/doc/morse/dev/adding_robot.rst
@@ -13,8 +13,10 @@ with::
 
  $ morse add robot <name> mysim
 
+This command creates and configures a template model of a robot, and explains
+how to modify it to suit your needs.
 
-Low-poly
+3D Model
 --------
 
 Blender is a 3D modeling software with both Photo-realistic Rendering and
@@ -22,8 +24,26 @@ Game Engine capabilities. In the first case, users want very detailed models
 with high definition textures. In one word, heavy models. Those are not suited
 for the Game Engine, where we want to get **real-time** rendering.
 
-MORSE' 3D models need to be light, with compressed textures, and as few polygons as
-possible.
+As such, it is advisable to prepare a lightweight ("low-poly") model of your
+robot, with compressed textures.
+
+The section :ref:`blender-advices` of :doc:`Adding a new
+component<adding_component>` provides some advices when creating a 3D model in
+Blender.
+
+Resources
++++++++++
+
+Blender got huge amount of models, you can find some on
+`Blendswap <http://www.blendswap.com/>`_. Make sure you look in the
+"**low-poly**" category for Game Engine models.
+
+You can also import many 3D format in Blender, for a full list, see the
+`Import-Export Blender wiki page
+<http://wiki.blender.org/index.php/Extensions:2.6/Py/Scripts/Import-Export>`_.
+
+For more on Blender Game modeling, see `Blender Cookie tutorials
+<http://cgcookie.com/blender/category/tutorials/game-development/>`_.
 
 
 Physics
@@ -131,17 +151,4 @@ See this `playlist of 5 videos on how to build a robot
     </iframe>
 
 
-Resources
----------
-
-Blender got huge amount of models, you can find some on
-`Blendswap <http://www.blendswap.com/>`_. Make sure you look in the
-"**low-poly**" category for Game Engine models.
-
-You can also import many 3D format in Blender, for a full list, see the
-`Import-Export Blender wiki page
-<http://wiki.blender.org/index.php/Extensions:2.6/Py/Scripts/Import-Export>`_.
-
-For more on Blender Game modeling, see `Blender Cookie tutorials
-<http://cgcookie.com/blender/category/tutorials/game-development/>`_.
 


### PR DESCRIPTION
This allows for the components' blend file to have extra objects
useful during models creation/edition (like lights) but not
desirable when the component is imported.