### PR TITLE
[sensors] Several fixes in the Collision sensor + large doc update

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -48,6 +48,9 @@ Sensors
 - Introduce the sensor Magnetometer which allows to compute the magnetic field
   vector of the Earth.
 - Extend the sensor IMU to return also the magnetic field vector.
+- Fixed the collision sensor: it now detects collision only when it is actually
+  colliding (before, any object in a 1x1x1m box around the sensor would return
+  a collision). While here, improve the documentation with a complete example.
 
 Modifiers
 ++++++++

--- a/doc/morse/what_new.rst
+++ b/doc/morse/what_new.rst
@@ -52,6 +52,11 @@ Sensors
   compute the magnetic field vector of the Earth.
 - Extend the sensor :doc:`user/sensors/imu`, to return also the magnetic field
   vector.
+- Fixed the :doc:`user/sensors/collision` sensor: it now detects collision only
+  when it is actually colliding (before, any object in a 1x1x1m box around the
+  sensor would return a collision). While here, improve the documentation with a
+  complete example.
+
 
 Modifiers
 +++++++++

--- a/src/morse/builder/sensors.py
+++ b/src/morse/builder/sensors.py
@@ -528,8 +528,9 @@ class Collision(SensorCreator):
     _classpath = "morse.sensors.collision.Collision"
 
     def __init__(self, name=None):
-        """ Sensor to detect objects colliding with the current object,
-        with more settings than the Touch sensor
+        """ Sensor to detect objects colliding with the current object.
+
+        Doc: https://www.blender.org/manual/game_engine/logic/sensors/collision.html
         """
         SensorCreator.__init__(self, name)
         obj = bpymorse.get_context_object()
@@ -538,23 +539,24 @@ class Collision(SensorCreator):
         obj.game.physics_type = 'SENSOR'
         # Specify a collision bounds type other than the default
         obj.game.use_collision_bounds = True
+        obj.scale = (0.02,0.02,0.02)
         # replace Always sensor by Collision sensor
         sensor = obj.game.sensors[-1]
         sensor.type = 'COLLISION'
         # need to get the new Collision Sensor object
         sensor = obj.game.sensors[-1]
         sensor.use_pulse_true_level = True # FIXME doesnt seems to have any effect
+        sensor.use_material = False # we want to filter by property, not by material
         # Component mesh (eye sugar)
         mesh = Cube("CollisionMesh")
-        mesh.scale = (.02, .02, .02)
         mesh.color(.8, .2, .1)
         self.append(mesh)
     def properties(self, **kwargs):
         SensorCreator.properties(self, **kwargs)
-        if 'collision_property' in kwargs:
+        if 'only_objects_with_property' in kwargs:
             try:
                 sensor = self._bpy_object.game.sensors[-1]
-                sensor.property = kwargs['collision_property']
+                sensor.property = kwargs['only_objects_with_property']
             except KeyError:
                 pass
 

--- a/testing/base/collision_testing.py
+++ b/testing/base/collision_testing.py
@@ -17,8 +17,10 @@ from pymorse import Morse
 
 def send_speed(s, sim, v=0, w=0, t=0):
     s.publish({'v': v, 'w': w})
-    sim.sleep(t)
-    s.publish({'v': 0.0, 'w': 0.0})
+
+    if t:
+        sim.sleep(t)
+        s.publish({'v': 0.0, 'w': 0.0})
 
 class CollisionTest(MorseTestCase):
     def setUpEnv(self):
@@ -34,7 +36,7 @@ class CollisionTest(MorseTestCase):
         robot.append(motion)
 
         collision = Collision()
-        collision.properties(collision_property="obstacle")
+        collision.properties(only_objects_with_property="obstacle")
         collision.add_stream('socket')
         collision.translate(x = 0.7, z = 0.2)
         robot.append(collision)
@@ -50,6 +52,11 @@ class CollisionTest(MorseTestCase):
 
             send_speed(sim.robot.motion, sim, 1.0, 0.0, 1.0)
 
+
+            collision = sim.robot.collision.get(timeout=0.1)
+            self.assertEqual(collision, None)
+            send_speed(sim.robot.motion, sim, 1.0, 0.0)
+            sim.sleep(1.0)
             collision = sim.robot.collision.get(timeout=0.1)
             self.assertNotEqual(collision, None)
             self.assertEqual(collision['objects'], "dala")


### PR DESCRIPTION
The collision sensor (as tested in Blender 2.74) was basically useless
since it would detect and return any collisions inside a 1x1x1m box
around the sensor. The unit-test was not checking this appropriately.

This commit scales down the collision bounding-box so that it matches
the mesh (a few cubic centimeters).

While here:
- renamed the property that allows to select which objects are checked
  for collision from 'collision_property' to
  'only_objects_with_property'
- large documentation update, in particular through a useful and
  complete example.


Note that this PR is motivated by a recent question on `morse-users`, that made me realize that our documentation is... poor in terms of actual useful examples. 