### PR TITLE
[core] Improve correctness of time handling in BestEffortStrategy

### DIFF
--- a/src/morse/builder/environment.py
+++ b/src/morse/builder/environment.py
@@ -380,6 +380,7 @@ class Environment(AbstractComponent):
         cube_obj = bpymorse.get_object(_dt_name)
         cube_obj.game.physics_type = 'DYNAMIC'
         cube_obj.hide_render = True
+        cube_obj.game.lock_location_z = True
 
         self._created = True
         # in case we are in edit mode, do not exit on error with CLI

--- a/src/morse/builder/environment.py
+++ b/src/morse/builder/environment.py
@@ -372,6 +372,15 @@ class Environment(AbstractComponent):
         hud_text = bpymorse.get_object('Keys_text')
         hud_text.scale.y = 0.027 # to fit the HUD_plane
 
+        # Create a cube to compute the dt between two frames
+        _dt_name = '__morse_dt_analyser'
+        cube = Cube(_dt_name)
+        cube.scale = (0.01, 0.01, 0.01)
+        cube.location = [0.0, 0.0, -5000.0]
+        cube_obj = bpymorse.get_object(_dt_name)
+        cube_obj.game.physics_type = 'DYNAMIC'
+        cube_obj.hide_render = True
+
         self._created = True
         # in case we are in edit mode, do not exit on error with CLI
         sys.excepthook = sys.__excepthook__ # Standard Python excepthook

--- a/src/morse/core/morse_time.py
+++ b/src/morse/core/morse_time.py
@@ -17,6 +17,7 @@ import time
 from morse.core import blenderapi
 from morse.helpers.statistics import Stats
 
+
 class BestEffortStrategy:
     def __init__ (self):
         self.time = time.time()
@@ -27,10 +28,19 @@ class BestEffortStrategy:
         self._last_time = 0.0
         self._nb_frame = 0
 
+        scene = blenderapi.scene()
+        for obj in scene.objects:
+            if obj.name == '__morse_dt_analyser':
+                self._morse_dt_analyser = obj
+
+        self._prepare_compute_dt()
+
         logger.info('Morse configured in Best Effort Mode')
 
     def update (self):
-        self.time = time.time()
+        self._dt = self._morse_dt_analyser.worldPosition[0] - self.px
+        self.time += self._dt
+        self._prepare_compute_dt()
         self._update_statistics()
 
     def name(self):
@@ -39,6 +49,10 @@ class BestEffortStrategy:
     @property
     def mean(self):
         return self._stat_jitter.mean
+
+    def _prepare_compute_dt(self):
+        self.px = self._morse_dt_analyser.worldPosition[0]
+        self._morse_dt_analyser.setLinearVelocity([1.0, 0.0, 0.0], True)
 
     def statistics(self):
         return {

--- a/src/morse/core/morse_time.py
+++ b/src/morse/core/morse_time.py
@@ -38,6 +38,18 @@ class BestEffortStrategy:
         logger.info('Morse configured in Best Effort Mode')
 
     def update (self):
+        """
+        The exact physical time elapsed between two logic call is hard
+        to guess. In the nominal case, it is easy, as long as you have
+        one logical step per render step. In other case, it depends on 
+        logic_max_step, physics_max_step, and "complex" internal logic.
+
+        So, instead of guessing it, observe it. Assuming the physical engine
+        is perfect, put a solid at one meter by sec on x axis, and observe
+        its displacement between two frame. We have:
+            dx = vx * dt
+        where vw = 1.0. So we have dx = dt.
+        """
         self._dt = self._morse_dt_analyser.worldPosition[0] - self.px
         self.time += self._dt
         self._prepare_compute_dt()


### PR DESCRIPTION
The implementation was correct in nominal case, basically when you have
one physical / logical step for one rendering step. In other cases,
the logic of Blender is a bit strange, and it is hard to guess what is
the real timestep between two frames. Exporting it  through an API would
be the good solution, but D728 is always in discussion.

So observe it using an indirect way. Put a solid at a certain speed, and
measure what is its displacement between this two frames. Assuming the
physical engine is perfect, we can compute the delta t between two
frames.
