### PR TITLE
Magnetic north

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -42,7 +42,10 @@ Sensors
 +++++++
 
 - **longitude**, **latitude** and **altitude** are not anymore properties of
-  the GPS sensor but must be set at the environment level.
+  the GPS sensor but must be set at the environment level. Moreover, the
+  property **angle_against_north** allows to configure the angle between the
+  X-axis and the geographic north (must be positive when the Blender X-axis is
+  East of true North, negative if is West of true North).
 - Introduce the new high-level sensor Attitude, allowing to compute the
   attitude of the system
 - Introduce the sensor Magnetometer which allows to compute the magnetic field

--- a/doc/morse/what_new.rst
+++ b/doc/morse/what_new.rst
@@ -45,7 +45,10 @@ Sensors
 +++++++
 
 - **longitude**, **latitude** and **altitude** are not anymore properties of
-  :doc:`user/sensors/gps` but must be set at the environment level.
+  :doc:`user/sensors/gps` but must be set at the environment level. Moreover,
+  the property **angle_against_north** allows to configure the angle between
+  the X-axis and the geographic north (must be positive when the Blender
+  X-axis is East of true North, negative if is West of true North).
 - Introduce the new high-level sensor :doc:`user/sensors/attitude`, allowing
   to compute the attitude of the system
 - Introduce the sensor :doc:`user/sensors/magnetometer`, which allows to

--- a/src/morse/helpers/coordinates.py
+++ b/src/morse/helpers/coordinates.py
@@ -1,6 +1,7 @@
 import logging; logger = logging.getLogger("morse." + __name__)
-from math import sqrt, cos, sin, tan, atan, radians, degrees
+from math import sqrt, cos, sin, tan, atan, radians, degrees, pi
 from morse.core import blenderapi
+from morse.helpers.morse_math import normalise_angle
 import numpy
 
 class CoordinateConverter:
@@ -113,3 +114,13 @@ class CoordinateConverter:
         cc = h * cos_lat + self.R * cos(lat_surface)
         lat_geoc = atan(s1 / cc)
         return degrees(lat_geoc)
+
+    def blender_to_ltp(self, xt):
+        return xt
+
+    def ltp_to_blender(self, xt):
+        return xt
+
+    def angle_against_north(self, orientation):
+        return pi / 2 - orientation[2]
+

--- a/src/morse/helpers/coordinates.py
+++ b/src/morse/helpers/coordinates.py
@@ -134,6 +134,6 @@ class CoordinateConverter:
     def ltp_to_blender(self,  xt):
         return xt * self._rot_ltp_blender
 
-    def angle_against_north(self, orientation):
+    def angle_against_geographic_north(self, orientation):
         return pi / 2 - (orientation[2] - self._angle_east)
 

--- a/src/morse/helpers/coordinates.py
+++ b/src/morse/helpers/coordinates.py
@@ -17,7 +17,7 @@ class CoordinateConverter:
 
     _instance = None
     
-    def __init__(self, latitude, longitude, altitude):
+    def __init__(self, latitude, longitude, altitude, angle_east_blender_x):
         P = [radians(longitude), radians(latitude), altitude]
         self.origin_ecef = self.geodetic_to_ecef(numpy.matrix(P))
         _rot = \
@@ -26,6 +26,13 @@ class CoordinateConverter:
            [cos(P[1]) * cos(P[0]), cos(P[1]) * sin(P[0]), sin(P[1])]]
         self._rot_ltp_ecef = numpy.matrix(_rot)
         self._rot_ecef_ltp = self._rot_ltp_ecef.T
+        _rot_east_x = \
+         [[cos(angle_east_blender_x), -sin(angle_east_blender_x), 0],
+          [sin(angle_east_blender_x), cos(angle_east_blender_x),  0],
+          [0, 0, 1]]
+        self._angle_east = angle_east_blender_x
+        self._rot_blender_ltp = numpy.matrix(_rot_east_x )
+        self._rot_ltp_blender = self._rot_blender_ltp.T
 
     @staticmethod
     def instance():
@@ -35,10 +42,16 @@ class CoordinateConverter:
                 latitude = ssr["latitude"]
                 longitude = ssr["longitude"]
                 altitude = ssr["altitude"]
+                try:
+                    angle_against_east = radians(ssr["angle_against_north"]) - pi / 2
+                except KeyError as e:
+                    angle_against_east = 0.0
                 CoordinateConverter._instance = \
-                    CoordinateConverter(latitude, longitude, altitude)
+                    CoordinateConverter(latitude, longitude, altitude, 
+                                        angle_against_east)
             except KeyError as e:
                 logger.error("Missing environment parameter %s\n", e)
+
         return CoordinateConverter._instance
 
     def geodetic_to_ecef(self, P):
@@ -116,11 +129,11 @@ class CoordinateConverter:
         return degrees(lat_geoc)
 
     def blender_to_ltp(self, xt):
-        return xt
+        return xt * self._rot_blender_ltp
 
-    def ltp_to_blender(self, xt):
-        return xt
+    def ltp_to_blender(self,  xt):
+        return xt * self._rot_ltp_blender
 
     def angle_against_north(self, orientation):
-        return pi / 2 - orientation[2]
+        return pi / 2 - (orientation[2] - self._angle_east)
 

--- a/src/morse/modifiers/ecef.py
+++ b/src/morse/modifiers/ecef.py
@@ -24,7 +24,6 @@ class ECEFmodifier(AbstractModifier):
 
     def initialize(self):
         self.converter = CoordinateConverter.instance()
-        self.method = None
 
     def modify(self):
         try:
@@ -48,11 +47,15 @@ class CoordinatesToECEF(ECEFmodifier):
     """
     def initialize(self):
         ECEFmodifier.initialize(self)
-        self.method = self.converter.ltp_to_ecef
+
+    def method(self, xt):
+        return self.converter.ltp_to_ecef(self.converter.blender_to_ltp(xt))
 
 class CoordinatesFromECEF(ECEFmodifier):
     """ Converts from UTM coordinates to Blender coordinates.
     """
     def initialize(self):
         ECEFmodifier.initialize(self)
-        self.method = self.converter.ecef_to_ltp
+
+    def method(self, xt):
+        return self.converter.blender_to_ltp(self.converter.ecef_to_ltp(xt))

--- a/src/morse/modifiers/geodetic.py
+++ b/src/morse/modifiers/geodetic.py
@@ -37,7 +37,8 @@ class CoordinatesToGeodetic(Geodeticmodifier):
                     self.data['y'],
                     self.data['z']
                     ])
-            xt = self.converter.ltp_to_geodetic(xe)
+            xt = self.converter.ltp_to_geodetic(
+                    self.converter.blender_to_ltp(xe))
 
             logger.debug("%s => %s" % (xe, xt))
 
@@ -58,7 +59,8 @@ class CoordinatesFromGeodetic(Geodeticmodifier):
                     radians(self.data['y']),
                     self.data['z']
                     ])
-            xt = self.converter.geodetic_to_ltp(xe)
+            xt = self.converter.ltp_to_blender(
+                    self.converter.geodetic_to_ltp(xe))
 
             logger.debug("%s => %s" % (xe, xt))
 

--- a/src/morse/sensors/attitude.py
+++ b/src/morse/sensors/attitude.py
@@ -100,5 +100,5 @@ class Attitude(morse.core.sensor.Sensor):
         self.local_data['rotation'] = self.position_3d.euler
         if self._use_angle_against_north:
             self.local_data['rotation'][2] = \
-            self._coord_converter.angle_against_north(self.position_3d.euler)
+            self._coord_converter.angle_against_geographic_north(self.position_3d.euler)
         self.local_data['angular_velocity'] = rates

--- a/src/morse/sensors/gps.py
+++ b/src/morse/sensors/gps.py
@@ -128,7 +128,7 @@ class GPS(morse.core.sensor.Sensor):
     add_data('altitude', 0.0, "double",
              'altitude in m a.s.l.', level = ["raw", "extended"])
     add_data('velocity', [0.0, 0.0, 0.0], "vec3<float>",
-             'Instantaneous speed in X, Y, Z, in meter sec^-1', level = ["raw", "extended"])
+             'Instantaneous speed along East, North, Up in meter sec^-1', level = ["raw", "extended"])
     add_data('date', 0000000, "DDMMYY",
              'current date in DDMMYY-format', level = "extended")
     add_data('time', 000000, "HHMMSS",
@@ -177,19 +177,9 @@ class RawGPS(GPS):
         # Call the constructor of the parent class
         GPS.__init__(self, obj, parent)
         
-        ##copied from accelerometer
-        # Variables to store the previous position
-        self.ppx = 0.0
-        self.ppy = 0.0
-        self.ppz = 0.0
-        # Variables to store the previous velocity
-        self.pvx = 0.0
-        self.pvy = 0.0
-        self.pvz = 0.0
-        # Make a new reference to the sensor position
-        self.p = self.bge_object.position
-        self.v = [0.0, 0.0, 0.0] # Velocity
-        self.pv = [0.0, 0.0, 0.0] # Previous Velocity
+        # Variables to store the previous LTP position
+        self.pltp = None
+        self.v = [0.0, 0.0, 0.0]
 
         self.coord_converter = CoordinateConverter.instance()
     
@@ -210,33 +200,13 @@ class RawGPS(GPS):
           http://www.lsgi.polyu.edu.hk/staff/zl.li/Vol_5_2/09-baki-3.pdf
         """
 
-        ####
-        #Speed
-        ####
-        ##copied from accelerometer
-        # Compute the difference in positions with the previous loop
-        self.dx = self.p[0] - self.ppx
-        self.dy = self.p[1] - self.ppy
-        self.dz = self.p[2] - self.ppz
-
-        # Store the position in this instant
-        self.ppx = self.p[0]
-        self.ppy = self.p[1]
-        self.ppz = self.p[2]
-
-        # Scale the speeds to the time used by Blender
-        self.v[0] = self.dx * self.frequency
-        self.v[1] = self.dy * self.frequency
-        self.v[2] = self.dz * self.frequency
-
-        # Update the data for the velocity
-        self.pvx = self.v[0]
-        self.pvy = self.v[1]
-        self.pvz = self.v[2]
-
         #current position
         xt = numpy.matrix(self.position_3d.translation)
         ltp = self.coord_converter.blender_to_ltp(xt)
+        if self.pltp is not None:
+            v = (ltp - self.pltp) * self.frequency
+            self.v = [v[0, 0], v[0, 1], v[0, 2]]
+        self.pltp = ltp
         gps_coords = self.coord_converter.ltp_to_geodetic(ltp)
 
         #compose message as close as possible to a GPS-standardprotocol

--- a/src/morse/sensors/gps.py
+++ b/src/morse/sensors/gps.py
@@ -27,6 +27,10 @@ class GPS(morse.core.sensor.Sensor):
             - **longitude** in degrees (double) of Blender origin
             - **latitude** in degrees (double) of Blender origin
             - **altitude** in m  of the Blender origin
+            - optionnaly **angle_against_north** in degrees is the angle
+              between geographic north and the blender X axis.
+              **angle_against_north** is positive when the blender X-axis is
+              east of true north, and negative when it is to the west.
 
     Conversion of Geodetic coordinates into ECEF-r, LTP into ECEF-r and vice versa
     ------------------------------------------------------------------------------

--- a/src/morse/sensors/gps.py
+++ b/src/morse/sensors/gps.py
@@ -247,7 +247,7 @@ class ExtendedGPS(RawGPS):
             # Not observable if we do not move
             self.local_data['heading'] = float("inf")
         else:
-            heading = self.coord_converter.angle_against_north(self.position_3d.euler)
+            heading = self.coord_converter.angle_against_geographic_north(self.position_3d.euler)
             self.local_data['heading'] = math.degrees(heading)
         self.local_data['date'] = date
         self.local_data['time'] = time_h_m_s   

--- a/src/morse/sensors/magnetometer.py
+++ b/src/morse/sensors/magnetometer.py
@@ -33,7 +33,8 @@ class MagnetoDriver(object):
 
     def compute(self, pose):
         pos = numpy.matrix(pose.translation)
-        pos_lla = self._coord_conv.ltp_to_geodetic(pos)
+        pos_ltp = self._coord_conv.blender_to_ltp(pos)
+        pos_lla = self._coord_conv.ltp_to_geodetic(pos_ltp)
         (decl, incl, f, h, x, y, z) = self._mag.compute(
                                  degrees(pos_lla[0, 0]),
                                  degrees(pos_lla[0, 1]),

--- a/src/morse/sensors/magnetometer.py
+++ b/src/morse/sensors/magnetometer.py
@@ -56,6 +56,10 @@ class Magnetometer(morse.core.sensor.Sensor):
             - **longitude** in degrees (double) of Blender origin
             - **latitude** in degrees (double) of Blender origin
             - **altitude** in m  of the Blender origin
+            - optionnaly **angle_against_north** in degrees is the angle
+              between geographic north and the blender X axis.
+              **angle_against_north** is positive when the blender X-axis is
+              east of true north, and negative when it is to the west.
     """
 
     _name = "Magnetometer"

--- a/testing/base/gps_testing.py
+++ b/testing/base/gps_testing.py
@@ -36,7 +36,6 @@ class GPSTest(MorseTestCase):
         robot.append(teleport)
         teleport.add_stream('socket')
 
-
         env = Environment('empty', fastmode = True)
         env.add_service('socket')
         env.properties(longitude = 43.6, latitude = 1.4333, altitude = 135.0)


### PR DESCRIPTION
This set to commit allow to handle a rotation between Blender frame and the LTP ENU frame (i.e. to configure the rotation between the X axis and the magnetic North). It is useful in several scenarios, where you have fixed frame, but still need some measurements against the "real" north.