### PR TITLE
Allowing environment class

### DIFF
--- a/src/morse/builder/environment.py
+++ b/src/morse/builder/environment.py
@@ -129,8 +129,17 @@ class Environment(AbstractComponent):
         If a name is already set (with 'obj.name=...'), it is used as it,
         and only the hierarchy is added to the name.
         """
+        import inspect
+        frame = inspect.currentframe()
+        frames = inspect.getouterframes(frame)
+        size_stack = len(frames)
+        for i in range(size_stack - 1, 0, -1):
+            if frames[i][3] == '__init__':
+                break
+        del frame
+        del frames
 
-        AbstractComponent.close_context(3)
+        AbstractComponent.close_context(i + 2)
 
         for component in AbstractComponent.components:
             if isinstance(component, Robot):


### PR DESCRIPTION
More stack introspection magic :)

This commit allows (indirectly) the possibility to create environment class. It permits to create ready to use environment, with default setting such as geolocalisation of the scene, magnetic north (#673), default camera position, and so on.  Previously, it fails miserably with an awful error in close_context  :)

