### PR TITLE
Faster than realtime

### DIFF
--- a/src/morse/blender/main.py
+++ b/src/morse/blender/main.py
@@ -623,6 +623,12 @@ def init_supervision_services():
     communication_service = Communication()
     time_service= TimeServices()
 
+    try:
+        time_scale = morse.core.blenderapi.getssr()['time_scale']
+        time_service.set_time_scale(time_scale)
+    except KeyError as e:
+        pass
+
     persistantstorage.serviceObjectDict[simulation_service.name()] = simulation_service
     persistantstorage.serviceObjectDict[communication_service.name()] = communication_service
     persistantstorage.serviceObjectDict[time_service.name()] = time_service

--- a/src/morse/builder/environment.py
+++ b/src/morse/builder/environment.py
@@ -525,6 +525,29 @@ class Environment(AbstractComponent):
 
         self.properties(time_management = strategy)
 
+    def set_time_scale(self, slowdown_by = None, accelerate_by = None):
+        """ Slow down or accelerate the simulation relative to real-time
+        (default behaviour: real-time simulation) by modifying the *time
+        scale* of the simulation.
+
+        :param slowndown_by: factor by which the simulation should be
+        slowed down, relative to real-time
+        :param accelerate_by: factor by which the simulation should be
+        accelerated, relative to real-time
+        You must pass only one of these options
+        """
+        if (not slowdown_by and not accelerate_by) or \
+           (slowdown_by and accelerate_by):
+            logger.error("You must call set_time_scale with exacltly one of "
+                         "the arguments \"slowdown_by\" or \"accelerate_by\"")
+            return
+
+        if slowdown_by:
+            self.properties(time_scale = 1.0 / slowdown_by)
+        else:
+            self.properties(time_scale = accelerate_by)
+
+
     def fullscreen(self, fullscreen=True):
         """ Run the simulation fullscreen
 

--- a/src/morse/core/blenderapi.py
+++ b/src/morse/core/blenderapi.py
@@ -298,3 +298,21 @@ def gravity():
             return mathutils.Vector((0.0, 0.0, -9.81))
     else:
         return None
+
+def clock_time():
+    if not fake:
+        if hasattr(bge.logic, 'getClockTime'):
+            return bge.logic.getClockTime()
+        else:
+            return -1
+    else:
+        return -1
+
+def frame_time():
+    if not fake:
+        if hasattr(bge.logic, 'getFrameTime'):
+            return bge.logic.getFrameTime()
+        else:
+            return -1
+    else:
+        return -1

--- a/src/morse/core/blenderapi.py
+++ b/src/morse/core/blenderapi.py
@@ -23,6 +23,8 @@ else:
     fake = True
 
 from morse.core import mathutils
+import logging
+logger = logging.getLogger("morse." + __name__)
 
 UPARROWKEY = None
 DOWNARROWKEY = None
@@ -316,3 +318,12 @@ def frame_time():
             return -1
     else:
         return -1
+
+def set_time_scale(time_scale):
+    if not fake:
+        if hasattr(bge.logic, 'setTimeScale'):
+            bge.logic.setTimeScale(time_scale)
+            return True
+        else:
+            logger.warning("setTimeScale requires at least Blender 2.77")
+    return False

--- a/src/morse/core/blenderapi.py
+++ b/src/morse/core/blenderapi.py
@@ -248,6 +248,12 @@ def getfrequency():
     else:
         return 0
 
+def setfrequency(value):
+    if not fake:
+        return bge.logic.setLogicTicRate(value)
+    else:
+        return 0
+
 class PersistantStorage(dict):
         __getattr__= dict.__getitem__
         __setattr__= dict.__setitem__

--- a/src/morse/services/time_services.py
+++ b/src/morse/services/time_services.py
@@ -8,6 +8,7 @@ class TimeServices(AbstractObject):
     def __init__(self):
         AbstractObject.__init__(self)
         self.time = blenderapi.persistantstorage().time
+        self.ref_fps = blenderapi.getfrequency()
         self._alarm_time = None
 
     def name(self):
@@ -37,6 +38,7 @@ class TimeServices(AbstractObject):
         Modify the time_scale parameter, allowing to slowing or
         accelerating time
         """
+        blenderapi.setfrequency(self.ref_fps * value)
         return blenderapi.set_time_scale(value)
 
     @async_service

--- a/src/morse/services/time_services.py
+++ b/src/morse/services/time_services.py
@@ -38,6 +38,10 @@ class TimeServices(AbstractObject):
         Modify the time_scale parameter, allowing to slowing or
         accelerating time
         """
+        logger.info("Changing time scale to %f. Your simulation is now running"
+                    " %f times %s than real-time." % (
+                    value, value if value >= 1.0 else 1.0 / value,
+                           "faster" if value >= 1.0 else "slower"))
         blenderapi.setfrequency(self.ref_fps * value)
         return blenderapi.set_time_scale(value)
 

--- a/src/morse/services/time_services.py
+++ b/src/morse/services/time_services.py
@@ -31,6 +31,14 @@ class TimeServices(AbstractObject):
         """
         return self.time.statistics()
 
+    @service
+    def set_time_scale(self, value):
+        """
+        Modify the time_scale parameter, allowing to slowing or
+        accelerating time
+        """
+        return blenderapi.set_time_scale(value)
+
     @async_service
     def sleep(self, time):
         """

--- a/testing/base/CMakeLists.txt
+++ b/testing/base/CMakeLists.txt
@@ -68,3 +68,4 @@ add_morse_test(imu_noise_testing)
 add_morse_test(communication_service_testing)
 
 add_morse_test(socket_sync_testing)
+add_morse_test(time_scale_testing)

--- a/testing/base/time_scale_testing.py
+++ b/testing/base/time_scale_testing.py
@@ -1,0 +1,100 @@
+#! /usr/bin/env python
+"""
+This script tests some of the base functionalities of MORSE.
+"""
+
+import sys
+import math
+import time
+from morse.testing.testing import MorseMoveTestCase
+from pymorse import Morse
+
+# Include this import to be able to use your test file as a regular 
+# builder script, ie, usable with: 'morse [run|exec] base_testing.py
+try:
+    from morse.builder import *
+except ImportError:
+    pass
+
+
+class TimeScale_Test(MorseMoveTestCase):
+    def setUpEnv(self):
+        """ Defines the test scenario, using the Builder API.
+        """
+        
+        robot = ATRV()
+
+        pose = Pose()
+        robot.append(pose)
+        pose.add_stream('socket')
+
+        motion = MotionVW()
+        robot.append(motion)
+        motion.add_stream('socket')
+
+        teleport = Teleport()
+        robot.append(teleport)
+        teleport.add_stream('socket')
+
+        env = Environment('empty', fastmode = True)
+        env.add_service('socket')
+
+    def send_speed(self, s, morse, v, w, t):
+        start = time.time()
+        self._count = 0
+        morse.robot.pose.subscribe(self.count_value)
+        s.publish({'v' : v, 'w' : w})
+        morse.sleep(t)
+        s.publish({'v' : 0.0, 'w' : 0.0})
+        morse.robot.pose.unsubscribe(self.count_value)
+        return time.time() - start
+
+    def count_value(self, value):
+        self._count += 1
+
+    def test_time_scale(self):
+        with Morse() as simu:
+
+            res = simu.rpc('time', 'set_time_scale', 1.0)
+            if not res:
+                logger.warning("time::set_time_scale is not supported on this Blender version")
+                return
+
+            simu.deactivate('robot.teleport')
+
+            precision = 0.125
+            time_precision = 0.02
+        
+            # Read the start position, it must be (0.0, 0.0, 0.0)
+            self.assertAlmostEqualPositionThenFix(simu, [0.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
+
+            v_w = simu.robot.motion
+
+            real_time_elapsed = self.send_speed(v_w, simu, 1.0, 0.0, 2.0)
+            self.assertAlmostEqualPositionThenFix(simu, [2.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
+            self.assertAlmostEqual(real_time_elapsed, 2.0, delta=time_precision)
+            self.assertEqual(self._count, 121)
+
+            real_time_elapsed = self.send_speed(v_w, simu, -1.0, 0.0, 2.0)
+            self.assertAlmostEqualPositionThenFix(simu, [0.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
+            self.assertAlmostEqual(real_time_elapsed, 2.0, delta=precision)
+            self.assertEqual(self._count, 121)
+
+
+            simu.rpc('time', 'set_time_scale', 0.5)
+            real_time_elapsed = self.send_speed(v_w, simu, 1.0, 0.0, 2.0)
+            self.assertAlmostEqualPositionThenFix(simu, [2.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
+            self.assertAlmostEqual(real_time_elapsed, 4.0, delta=time_precision)
+            self.assertEqual(self._count, 241)
+
+            simu.rpc('time', 'set_time_scale', 2.0)
+            real_time_elapsed = self.send_speed(v_w, simu, -1.0, 0.0, 2.0)
+            self.assertAlmostEqualPositionThenFix(simu, [0.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
+            self.assertAlmostEqual(real_time_elapsed, 1.0, delta=precision)
+            self.assertEqual(self._count, 61)
+
+
+########################## Run these tests ##########################
+if __name__ == "__main__":
+    from morse.testing.testing import main
+    main(TimeScale_Test, time_modes = [TimeStrategies.BestEffort])

--- a/testing/base/time_scale_testing.py
+++ b/testing/base/time_scale_testing.py
@@ -25,6 +25,7 @@ class TimeScale_Test(MorseMoveTestCase):
         robot = ATRV()
 
         pose = Pose()
+        pose.frequency(60)
         robot.append(pose)
         pose.add_stream('socket')
 
@@ -40,14 +41,19 @@ class TimeScale_Test(MorseMoveTestCase):
         env.add_service('socket')
 
     def send_speed(self, s, morse, v, w, t):
-        start = time.time()
+        """
+        Send the speed (v, w) to the robot controller during real-time t
+        seconds
+        Return the simulated time elapsed (in sec)
+        """
+        start = morse.time()
         self._count = 0
         morse.robot.pose.subscribe(self.count_value)
         s.publish({'v' : v, 'w' : w})
-        morse.sleep(t)
+        time.sleep(t)
         s.publish({'v' : 0.0, 'w' : 0.0})
         morse.robot.pose.unsubscribe(self.count_value)
-        return time.time() - start
+        return morse.time() - start
 
     def count_value(self, value):
         self._count += 1
@@ -62,7 +68,7 @@ class TimeScale_Test(MorseMoveTestCase):
 
             simu.deactivate('robot.teleport')
 
-            precision = 0.125
+            precision = 0.18
             time_precision = 0.04
         
             # Read the start position, it must be (0.0, 0.0, 0.0)
@@ -70,28 +76,38 @@ class TimeScale_Test(MorseMoveTestCase):
 
             v_w = simu.robot.motion
 
-            real_time_elapsed = self.send_speed(v_w, simu, 1.0, 0.0, 2.0)
+            # Normal speed: one real-time second == one simulated second
+            simu_time_elapsed = self.send_speed(v_w, simu, 1.0, 0.0, 2.0)
+            # as a consequence, the robot has moved forward by 2 m
             self.assertAlmostEqualPositionThenFix(simu, [2.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
-            self.assertAlmostEqual(real_time_elapsed, 2.0, delta=time_precision)
-            self.assertEqual(self._count, 121)
+            self.assertAlmostEqual(simu_time_elapsed, 2.0, delta=time_precision)
+            # We expect to get 60 (default fps) * 2 (s) pose measurement
+            self.assertAlmostEqual(self._count, 120, delta = 1)
 
-            real_time_elapsed = self.send_speed(v_w, simu, -1.0, 0.0, 2.0)
+            simu_time_elapsed = self.send_speed(v_w, simu, -1.0, 0.0, 2.0)
             self.assertAlmostEqualPositionThenFix(simu, [0.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
-            self.assertAlmostEqual(real_time_elapsed, 2.0, delta=precision)
-            self.assertEqual(self._count, 121)
+            self.assertAlmostEqual(simu_time_elapsed, 2.0, delta=precision)
+            self.assertAlmostEqual(self._count, 120, delta = 1)
 
 
+            # Slow down the simulation : one real-time second == 500 ms simulated
             simu.rpc('time', 'set_time_scale', 0.5)
-            real_time_elapsed = self.send_speed(v_w, simu, 1.0, 0.0, 2.0)
-            self.assertAlmostEqualPositionThenFix(simu, [2.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
-            self.assertAlmostEqual(real_time_elapsed, 4.0, delta=time_precision)
-            self.assertEqual(self._count, 121)
+            simu_time_elapsed = self.send_speed(v_w, simu, 1.0, 0.0, 2.0)
+            # as a consequence, we only have moved forward by 1m in
+            # 2 real-second (1 simulated second)
+            self.assertAlmostEqualPositionThenFix(simu, [1.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
+            self.assertAlmostEqual(simu_time_elapsed, 1.0, delta=time_precision)
+            # and so we get only 60 measures (as we will simulate 1 sec in simulate time)
+            self.assertAlmostEqual(self._count, 60, delta = 1)
 
+            # Accelerate the simulation : one real-time second == 2 simulated second
             simu.rpc('time', 'set_time_scale', 2.0)
-            real_time_elapsed = self.send_speed(v_w, simu, -1.0, 0.0, 2.0)
-            self.assertAlmostEqualPositionThenFix(simu, [0.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
-            self.assertAlmostEqual(real_time_elapsed, 1.0, delta=precision)
-            self.assertEqual(self._count, 121)
+            simu_time_elapsed = self.send_speed(v_w, simu, -1.0, 0.0, 2.0)
+            # as a consequence, we only have moved downward by 4m in 2 real-second (4 simulated second)
+            self.assertAlmostEqualPositionThenFix(simu, [-3.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
+            self.assertAlmostEqual(simu_time_elapsed, 4.0, delta=precision)
+            # alse, we get 240 measures (60 * 4 simulated sec)
+            self.assertAlmostEqual(self._count, 240, delta = 2)
 
 
 ########################## Run these tests ##########################

--- a/testing/base/time_scale_testing.py
+++ b/testing/base/time_scale_testing.py
@@ -63,7 +63,7 @@ class TimeScale_Test(MorseMoveTestCase):
             simu.deactivate('robot.teleport')
 
             precision = 0.125
-            time_precision = 0.02
+            time_precision = 0.04
         
             # Read the start position, it must be (0.0, 0.0, 0.0)
             self.assertAlmostEqualPositionThenFix(simu, [0.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
@@ -85,13 +85,13 @@ class TimeScale_Test(MorseMoveTestCase):
             real_time_elapsed = self.send_speed(v_w, simu, 1.0, 0.0, 2.0)
             self.assertAlmostEqualPositionThenFix(simu, [2.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
             self.assertAlmostEqual(real_time_elapsed, 4.0, delta=time_precision)
-            self.assertEqual(self._count, 241)
+            self.assertEqual(self._count, 121)
 
             simu.rpc('time', 'set_time_scale', 2.0)
             real_time_elapsed = self.send_speed(v_w, simu, -1.0, 0.0, 2.0)
             self.assertAlmostEqualPositionThenFix(simu, [0.0, 0.0, 0.10, 0.0, 0.0, 0.0], precision)
             self.assertAlmostEqual(real_time_elapsed, 1.0, delta=precision)
-            self.assertEqual(self._count, 61)
+            self.assertEqual(self._count, 121)
 
 
 ########################## Run these tests ##########################


### PR DESCRIPTION
It is the first attempt to handle #338. You need blender-current (and python 3.5) to test it.

I still have doubt on the interface. 

set_time_scale for moment only changes time_scale, and not fps. fps in blender is really frame by real second. So it means that if you set the time_scale by two, you will get sensor information at 30Hz (simulated time). It is possible to automatically adjust fps to have frame by simulated second constant (but we may need to raise max_logic_step / max_physics_step), and we need to handle #683 too. I suppose it can raise problem too if we have a really low time_scale too (but who really need that).

Your through ?