### PR TITLE
Ackerman new model

### DIFF
--- a/src/morse/core/wheeled_robot.py
+++ b/src/morse/core/wheeled_robot.py
@@ -4,6 +4,7 @@ import morse.core.robot
 from morse.core import blenderapi
 from morse.helpers.components import add_property
 from morse.helpers.joints import Joint6DoF
+import math
 
 class PhysicsWheelRobot(morse.core.robot.Robot):
     """ Abstract base class for robots with wheels that turn as
@@ -58,6 +59,10 @@ class PhysicsWheelRobot(morse.core.robot.Robot):
 
     def get_track_width(self):
         vec = self._wheels['FL'].getVectTo(self._wheels['FR'])
+        return vec[0]
+
+    def get_distance_axle(self):
+        vec = self._wheels['FL'].getVectTo(self._wheels['RL'])
         return vec[0]
 
     def get_wheel_radius(self, wheel_name):
@@ -177,4 +182,148 @@ class PhysicsDifferentialRobot(PhysicsWheelRobot):
 
             logger.debug("New speeds set: left=%.4f, right=%.4f" %
                          (w_ws_l, w_ws_r))
+
+class PhysicsAckermannRobot(PhysicsWheelRobot):
+    """
+    Base class for mobile robots following the Ackermann steering principle
+
+    This base class handles the simulation of the physical interactions
+    between Ackermann-like vehicle and the ground.
+    It assumes the vehicle has 4 wheels.
+    """
+
+    add_property('_max_steering_angle', 45.0, 'max_steering_angle', 'double', 
+                 'The bigger angle possible the vehicle is able to turn \
+                 its front wheel (in degree)')
+
+    def __init__ (self, obj, parent=None):
+        """ Constructor method. """
+        # Call the constructor of the parent class
+        PhysicsWheelRobot.__init__(self, obj, parent)
+
+        # get wheel references and ID's
+        self.get_wheels()
+
+        self._max_steering_angle = math.radians(self._max_steering_angle)
+
+        # construct the vehicle
+        self.build_vehicle()
+
+        self._axle_distance = self.get_distance_axle()
+
+        logger.warn("Using wheel separation of %.4f" % self._trackWidth)
+
+        # Force speed at 0.0 at startup
+        self.apply_vw_wheels(0.0, 0.0)
+
+
+    def build_vehicle(self):
+        """ Apply the constraints to the vehicle parts. """
+        # get track width
+        self._trackWidth = self.get_track_width()
+
+        # set up wheel constraints
+        # add wheels to either suspension arms or vehicle chassis
+        if self._has_suspension:
+            self.build_model_with_suspension()
+        else:
+            self.build_model_without_suspension()
+
+    def build_model_without_suspension(self):
+        """ Add all the constraints to attach the wheels to the body """
+        for index in ['FR', 'FL']:
+            self._wheel_joints[index] = self.attach_front_wheel_to_body(
+                    self._wheels[index], self.bge_object)
+        for index in ['RR', 'RL']:
+            self._wheel_joints[index] = self.attach_rear_wheel_to_body(
+                    self._wheels[index], self.bge_object)
+
+    def attach_front_wheel_to_body(self, wheel, parent):
+        """ Attaches the wheel to the given parent using a 6DOF constraint
+
+        Set the wheel positions relative to the robot in case the
+        chassis was moved by the builder script or manually in blender
+        """
+        joint = Joint6DoF(wheel, parent)
+        joint.limit_rotation_dof('Y', -self._max_steering_angle, self._max_steering_angle)
+        joint.free_rotation_dof('Z')
+        return joint # return a reference to the constraint
+
+
+    def attach_rear_wheel_to_body(self, wheel, parent):
+        """ Attaches the wheel to the given parent using a 6DOF constraint
+
+        Set the wheel positions relative to the robot in case the
+        chassis was moved by the builder script or manually in blender
+        """
+        joint = Joint6DoF(wheel, parent)
+        joint.free_rotation_dof('Z')
+        return joint # return a reference to the constraint
+
+    def apply_vw_wheels(self, vx, vw):
+        """ Apply (v, w) to the parent robot. """
+
+        velocity_control = 'Z' 
+        steering_control = 'Y'
+
+        # calculate desired wheel speeds and set them
+        if abs(vx) < 0.001 and abs(vw) < 0.001:
+            # stop the wheel when velocity is below a given threshold
+            for index in ['RL', 'RR']:
+                self._wheel_joints[index].angular_velocity(velocity_control, 0)
+            for index in ['FR', 'FL']:
+                self._wheel_joints[index].angular_velocity(steering_control, 0)
+
+            self._stopped = True
+        else:
+            # this is need to "wake up" the physic objects if they have
+            # gone to sleep apply a tiny impulse straight down on the
+            # object
+            if self._stopped:
+                self.bge_object.applyImpulse(
+                   self.bge_object.position, (0.0, 0.0, 0.000001))
+
+            # no longer stopped
+            self._stopped = False
+
+            # speed of rear wheels
+            wx = -1.0 * vx / self._wheel_radius
+            for index in ['RL', 'RR']:
+                self._wheel_joints[index].angular_velocity(velocity_control, wx)
+
+            logger.debug("Rear wheel speeds set to %.4f" % wx)
+
+            # Compute angle of steering wheels
+            if abs(vw) > 0.01:
+                radius = vx / vw
+                if abs(radius) < (self._trackWidth / 2):
+                    l_angle = math.copysign(self._max_steering_angle, radius)
+                    r_angle = math.copysign(self._max_steering_angle, radius)
+                else:
+                    cot_l_angle = self._axle_distance / (radius + (self._trackWidth / 2))
+                    cot_r_angle = self._axle_distance / (radius -  (self._trackWidth / 2))
+                    l_angle = math.atan(cot_l_angle)
+                    r_angle = math.atan(cot_r_angle)
+                    logger.debug('virtual angle %f' % (math.atan(self._axle_distance / radius)))
+            else:
+                l_angle = r_angle = 0.0
+
+            logger.info("l_angle %f r_angle %f" % (l_angle, r_angle))
+
+            if abs(l_angle) >= self._max_steering_angle or \
+               abs(r_angle) >= self._max_steering_angle:
+                logger.warning("Constraint (v = %f, w = %f) is not applicable \
+                               due to physical limitation" % (vx, vw))
+
+            current_l_angle = self._wheel_joints['FL'].euler_angle(steering_control)
+            current_r_angle = self._wheel_joints['FR'].euler_angle(steering_control)
+
+            diff_l_angle = l_angle - current_l_angle
+            diff_r_angle = r_angle - current_r_angle
+
+            self._wheel_joints['FL'].angular_velocity(steering_control, diff_l_angle)
+            self._wheel_joints['FR'].angular_velocity(steering_control, diff_r_angle)
+
+            logger.debug("Angle left w %f right w %f" % (diff_l_angle, diff_r_angle))
+
 

--- a/src/morse/helpers/controller.py
+++ b/src/morse/helpers/controller.py
@@ -1,0 +1,62 @@
+""" 
+A collection of simple controllers
+
+For now, implement only a simple PID controller
+"""
+import logging
+logger = logging.getLogger("morse." + __name__)
+from morse.core import blenderapi
+
+def clamp(n, smallest, largest): 
+    return max(smallest, min(n, largest))
+
+class PIDController(object):
+    def __init__(self, kp=1.0, kd=1.0, ki=1.0, limits_integrator = 10.0):
+        self.kp = kp
+        self.kd = kd
+        self.ki = ki
+
+        self._setpoint = 0.0
+
+        self._last_time = 0.0
+        self._last_error = 0.0
+
+        self._integrator = 0.0
+        self._limits_integrator = limits_integrator
+
+    @property
+    def setpoint(self):
+        return self._setpoint
+
+    @setpoint.setter
+    def setpoint(self, new_setpoint):
+        if (abs(self._setpoint - new_setpoint) > 0.1):
+            self.reset()
+        self._setpoint = new_setpoint
+
+    def reset(self):
+        self.last_error = 0.0
+        self._last_time = 0.0
+        self._integrator = 0.0
+
+    def update(self, measured_value):
+        error = self._setpoint - measured_value
+        current_time = blenderapi.persistantstorage().time.time
+
+        # Calculate the derivative of the error
+        timediff = current_time - self._last_time
+        if timediff > 0:
+            error_diff = (error - self._last_error) / timediff
+        else:
+            error_diff = 0.0
+
+        # Remember values for next time
+        self._last_error = error
+        self._last_time = current_time
+
+        self._integrator += error
+        self._integrator = clamp(self._integrator,
+                                 -self._limits_integrator,
+                                  self._limits_integrator)
+
+        return self.kp * error + self.kd * error_diff + self.ki * self._integrator

--- a/src/morse/helpers/joints.py
+++ b/src/morse/helpers/joints.py
@@ -78,3 +78,9 @@ class Joint6DoF(object):
     def angular_spring(self, axis, spring, damping):
         self._joint.setParam(_param_id(15, axis), spring, damping)
 
+    def pos(self, axis):
+        return self._joint.getParam(_param_id(0, axis))
+
+    def euler_angle(self, axis):
+        return self._joint.getParam(_param_id(3, axis))
+


### PR DESCRIPTION
This set of commit introduces an Ackermann (car-like) generic model for Morse. It also introduce a PID controller, which can be reused, at least in the RotorCraft related actuators.

There is no specific actuator for now, one can abuse 'DifferentialVWActuator'. My idea (but it will be another pull request) is to use the same interface for PhysicalRobot (i.e. apply_speed), and so use for 'all' robots VWMotion. 

There is no robot commited related to this new model, I can provide one if needed, through I don't think it deserves to be in Morse for now (it is just a cube, and four cylinders, without any texture).

Please review the code, and discuss the various item of this PR.