### PR TITLE
Stopped pymorse stream class from swallowing error messages

### DIFF
--- a/bindings/pymorse/src/pymorse/stream.py
+++ b/bindings/pymorse/src/pymorse/stream.py
@@ -12,6 +12,7 @@ import logging
 import asyncore
 import asynchat
 import threading
+import traceback
 # Double-ended queue, thread-safe append/pop.
 from collections import deque
 
@@ -80,6 +81,7 @@ class StreamB(asynchat.async_chat):
 
     def handle_error(self):
         self.error = True
+        logger.error('Exception occurred in asynchronous socket handler:\n%s'%traceback.format_exc())
         self.handle_close()
 
     #### IN ####


### PR DESCRIPTION
Previously, when an error occurred in one of the asynchronous socket handlers represented in pymorse's Stream class, the socket was closed without printing or logging any error message, making errors in callbacks given to socket handlers impossible to debug.  Now the error is sent to the logger before the socket is closed.