### PR TITLE
Corrected/improved the English + queries

### DIFF
--- a/doc/morse/user/basic_morse.rst
+++ b/doc/morse/user/basic_morse.rst
@@ -19,7 +19,7 @@ To start the simulation right away, do::
 Where ``filename`` can be a Blender file or a Python script that uses the
 :doc:`Builder API <../user/builder>` to describe a simulation scenario.
 
-To load the simulation scenario in the Blender interface::
+To load the simulation scene in the Blender interface::
 
   $ morse edit <filename>
 
@@ -47,7 +47,7 @@ MORSE controls
 
 A simulation in MORSE is executed using the Game Engine mode of Blender. When
 in this mode, the button panels of Blender are disabled and the controls
-change.  When running ``morse edit <filename>``, it is recommended to switch
+change.  When running ``morse edit <filename>``, we recommended switching
 the Blender 3D View window to full screen before starting a simulation. Press
 :kbd:`Ctrl-Up` when the mouse is over a window to toggle it to full screen and
 back.
@@ -55,10 +55,10 @@ back.
 Simulation camera control
 +++++++++++++++++++++++++
 
-The default MORSE scene, as well as most of the provided scenario files,
-contain an object called **CameraFP**.  It allows the user to control the
+The default MORSE scene, as well as most of the provided scene files,
+contains an object called **CameraFP**.  It allows the user to control the
 view of the scene during the simulation, using the mouse and keyboard,
-in the same way as First Person Shooter game. The camera can be moved around
+in the same way as a First Person Shooter game. The camera can be moved around
 using:
     
 - :kbd:`w`/:kbd:`z`, :kbd:`s` to move forward and backward
@@ -75,7 +75,7 @@ camera object: **Sensitivity** for the mouse, and **Speed** for the keyboard.
 Standard keyboard functions
 +++++++++++++++++++++++++++
 
-The following are key bindings already defined in any simulation scene
+The following are the default key bindings defined in any simulation scene
 
 - :kbd:`p` key: start the simulation (initiate the Game Engine)
 
@@ -101,13 +101,13 @@ The following are key bindings already defined in any simulation scene
   the simulation
 
 .. warning::  
-  There is a bug in the code, which will make any forces acting on an object be
-  still active when the position is reset. This can cause an object to start
-  rotating or moving without an apparent reason.
+  There is a bug in the code, which will make any forces acting on an object
+  continue to be active when the position is reset. This can cause an object to start
+  rotating or moving for no apparent reason.
 
 - :kbd:`F12` key: emergency exit from the simulation, without clean up. Useful
   when the :kbd:`Esc` key does not make the simulation finish (generally happens
-  when the simulation could not properly initialise)
+  when the simulation could not properly initialise).
 
 .. note::  
   If this doesn't work either, switch to the command terminal where MORSE was

--- a/doc/morse/user/basic_morse.rst
+++ b/doc/morse/user/basic_morse.rst
@@ -77,7 +77,7 @@ Standard keyboard functions
 
 The following are the default key bindings defined in any simulation scene
 
-- :kbd:`p` key: start the simulation (initiate the Game Engine)
+- :kbd:`p` key: start the simulation (initialise the Game Engine)
 
 - :kbd:`h` key: show an on screen display with this list of keyboard functions
 


### PR DESCRIPTION
My morse doesn't match the above:

$ morse -h
usage: morse [-h] [-n] [-c] [--reverse-color] [-v]
             {create,import,rm,add,check,run,edit} ...

The Modular OpenRobots Simulation Engine

optional arguments:
  -h, --help            show this help message and exit
  -n, --noaudio         dont look for sound card
  -c, --color           uses colors for MORSE output.
  --reverse-color       uses darker colors for MORSE output.
  -v, --version         returns the current MORSE version

modes:
  type 'morse <mode> --help' for details

  {create,import,rm,add,check,run,edit}
    create              creates a new simulation environment in the current
                        directory.
    import              imports a pre-existing simulation environment.
    rm                  deletes an existing simulation environment.
    add                 adds a template for a component to an environment.
    check               checks your environment is correctly configured.
    run                 starts a simulation.
    edit                opens an existing scene for edition.
$ morse -v
morse UNKNOWN-dirty

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.1 LTS
Release:	16.04
Codename:	xenial


Also, you say Ctrl+Up toggles full screen but for me it is Alt+F11.

Finally "initiate the Game Engine" is incorrect but I don't know what your intented meaning is. Perhaps you mean "run the Game Engine" or "start the Game Engine"?