### PR TITLE
Corrected/improved the English + comments

### DIFF
--- a/doc/morse/dev/adding_datastream_handler.rst
+++ b/doc/morse/dev/adding_datastream_handler.rst
@@ -1,11 +1,11 @@
 Adding a  new datastream handler
 ================================
 
-Datastream handlers allow to transform the internal MORSE model into a
-specific serialization type, expected by your specific architecture.
+Datastream handlers allow you to transform the internal MORSE model into the
+serialization form expected by your specific architecture.
 
-Here, we explain how to add a specific handler for a specific message, in case 
-where there is already some infrastructure for your middleware in MORSE
+Here, we explain how to add a custom handler for a specific message, for when
+there is already some infrastructure for your middleware in MORSE.
 
 If you want to implement a completely new middleware, refer to
 :doc:`new_middleware`.
@@ -21,15 +21,15 @@ contains the actual serialization or deserialization routine. In this method,
 you can use ``self.data`` to access to the ``local_data`` field of the
 associated component.
 
-It can be interesting too to overriding the ``initialize`` and ``finalize``
-method, which contains respectively the initialisation code, and the
+It can also be useful to override the ``initialize`` and ``finalize``
+methods, which contain the initialisation code, and the
 finalisation code. Do not override ``__init__`` and ``__del__``.
 
-Last, you can set the ``_type_name`` field, and the ``_type_url`` field to
-explicit which type is imported (or exported) with this datastream handler,
+Lastly, you can set the ``_type_name`` field, and the ``_type_url`` field to
+specify which type is imported (or exported) with this datastream handler,
 and where to find some documentation about it.
 
-Let see an example with a custom socket handler.
+Let's see an example with a custom socket handler.
 
 .. code-block:: python
 
@@ -70,16 +70,16 @@ Now, you can test your new datastream handler directly in the builder:
     env = Environment('empty', fastmode=True)
 
 
-Last, if you want to use it more easily, you can add some entries in
+Lastly, if you want to use it more easily, you can add some entries in
 :py:data:`morse.builder.data.MORSE_DATASTREAM_DICT`.
 
-Adding a new datastream handler : specificities
------------------------------------------------
+Adding a new datastream handler : specifics
+-------------------------------------------
 
-Generally speaking, the code to send or receive message is the same for all
-datastream handler of one middleware, and so it is often shared. In this
-section, we outline the specificities of each middleware, which make it easier
-to write datastream handler for it.
+Generally speaking, the code to send or receive a message is the same for all
+of a particular middleware's datastreams, and so it is often shared. In this
+section, we outline the specifics of each middleware, which make it easier
+to write a datastream handler for it.
 
 Text middleware :tag:`text`
 +++++++++++++++++++++++++++
@@ -88,7 +88,7 @@ Text middleware only supports sensors output. It provides a base class
 :py:class:`morse.middleware.text_datastream.BasePublisher` which deals properly
 with file handling, name selection, etc. To write a specific text handler, you
 want to derive from this base class and reimplement the ``header`` method
-(what write in the head of the file) and the ``encode_data`` method (how
+(what to write in the head of the file) and the ``encode_data`` method (how
 to write data in the file). 
 
 .. code-block:: python
@@ -137,11 +137,11 @@ encoder.
 Yarp middleware :tag:`yarp`
 +++++++++++++++++++++++++++
 
-Yarp middleware provide the
+Yarp middleware includes
 :py:class:`morse.middleware.yarp_datastream.YarpPort` which provides basic
 encapsulation of the Yarp protocol. A specialized class
 :py:class:`morse.middleware.yarp_datastream.YarpPublisher` provides facilities
-to send content through a `Yarp::Bottle`. If you want to use such transport,
+to send content through a `Yarp::Bottle`. If you want to use this transport,
 you can override the method
 :py:meth:`morse.middleware.yarp_datastream.YarpPublisher.encode` to provide
 specialized behaviour.
@@ -160,16 +160,16 @@ specialized behaviour.
 Ros middleware :tag:`ros`
 +++++++++++++++++++++++++
 
-Ros middleware provides two useful base class
-:py:class:`morse.middleware.ros.abstract_ros.ROSSubscriber` and
-:py:class:`morse.middleware.ros.abstract_ros.ROSPublisher`, respectively for
-actuator and sensor. In particular, they provide some facilities to manage
-topics. If you use these classes, you do not need to define ``_type_name`` and
-``_type_url``, but to fill ``ros_class``, the previous information will be
-derived automatically from it. If you write a Reader, you need to override the
+Ros middleware provides two useful base classes:
+:py:class:`morse.middleware.ros.abstract_ros.ROSSubscriber` for actuators, and
+:py:class:`morse.middleware.ros.abstract_ros.ROSPublisher` for
+sensors. In particular, they provide some facilities to manage
+topics. If you use these classes, you do not need to define ``_type_name`` or
+``_type_url``, but instead must set ``ros_class``, from which the ``_type_name`` and
+``_type_url`` will automatically be derived. If you write a Reader, you need to override the
 :py:meth:`morse.middleware.ros.abstract_ros.ROSSubscriber.update` method, which
-takes a message and must modifier ``self.data`` accordingly. For a Publisher,
-you need to override inherited ``default`` method. Don't forget to call
+takes a message and must modify ``self.data`` accordingly. For a Publisher,
+you need to override the inherited ``default`` method. Don't forget to call
 ``self.publish(msg)`` otherwise nothing will happen.
 
 .. code-block:: python
@@ -195,17 +195,17 @@ Pocolibs middleware :tag:`pocolibs`
 Pocolibs middleware provides
 :py:class:`morse.middleware.pocolibs_datastream.PocolibsDataStreamOutput` for sensors,
 and :py:class:`morse.middleware.pocolibs_datastream.PocolibsDataStreamInput` for
-actuators which deals with the low-level details of Pocolibs. To write a custom
-encoder, you need to subclass the correct class, and provides both overriding
-for ``initialize`` and ``default``. In ``initialize``, do not forget to call
-the mother ``initialize`` method which the desired type. In the ``default``
-method, do not forget to call respectively ``read`` or ``write``.
+actuators, and which deal with the low-level details of Pocolibs. To write a custom
+encoder, you need to subclass the correct class, and override both the
+``initialize`` and ``default`` methods. In ``initialize``, remember to call
+the parent class' ``initialize`` method with the desired type. In the ``default``
+method, remember to call ``read`` or ``write`` as appropriate.
 
 .. note::
 
-    Structures imported by pocolibs interface used ctypes. Please read the
+    Structures imported by the pocolibs interface use ctypes. Please read the
     `ctype documentation <http://docs.python.org/3.2/library/ctypes.html>`_
-    properly before doing strange things.
+    properly to avoid strange things happening.
 
 
 .. code-block :: python
@@ -239,10 +239,10 @@ Moos middleware interface provides
 with some low-level details of Moos. You still need to write your specialized
 `default` implementation, calling:
 
-- ``self.m.Notify()`` to export data to the databases (sensor from the point of
-  view of Morse)
+- ``self.m.Notify()`` to export data to the databases (sensor from Morse's point of
+  view)
 - ``self.m.FetchRecentMail()`` to get last messages from the databases
-  (actuator from the point of view of Morse).
+  (actuator from Morse's point of view).
 
 .. code-block:: python
 
@@ -265,7 +265,7 @@ HLA middleware :tag:`hla`
 HLA middleware provides several facilities, i.e.
 :py:class:`morse.middleware.hla.abstract_hla.AbstractHLAOutput` for sensors, and
 :py:class:`morse.middleware.hla.abstract_hla.AbstractHLAInput` for actuators, to
-deal with common HLA stuff. An important thing for HLA datastream handler is
+deal with common HLA stuff. Important for HLA datastream handlers is the
 ``_hla_name``, which defines the name desired / expected from the federation.
 The default name is the robot parent name. Otherwise, the structure of a
 HLA actuator datastream handler looks like:
@@ -277,7 +277,7 @@ HLA actuator datastream handler looks like:
 
     class CertiTestInput(AbstractHLAInput):
         def initialize(self):
-            AbstractHLAInput.initialize(self)
+            super().initialize()
 
             # Grab handler to objects and attribute handles
             bille_handle = self.amb.object_handle('Bille')
@@ -299,15 +299,14 @@ HLA actuator datastream handler looks like:
 
 On the other side, the initialize is quite symmetric (i.e. get handles over
 objects and attributes, and then publish them. The construction of the output
-is done in the following way
+is done in the following way:
 
 .. code-block:: python
 
     class CertiTestOutput(AbstractHLAOutput):
         def default(self, ci = 'unused'):
-            to_send =  \
-                    {self.handle_x: MessageBufferWriter().write_double(self.data['x']),
-                     self.handle_y: MessageBufferWriter().write_double(self.data['y'])}
+            to_send = {self.handle_x: MessageBufferWriter().write_double(self.data['x']),
+                       self.handle_y: MessageBufferWriter().write_double(self.data['y'])}
             self.update_attribute(to_send)
 
 Mavlink middleware :tag:`mavlink`
@@ -316,11 +315,11 @@ Mavlink middleware :tag:`mavlink`
 Morse provides facilities to help the interoperability with Mavlink, with the
 classes :py:class:`morse.middleware.mavlink.abstract_mavlink.MavlinkSensor`
 and :py:class:`morse.middleware.mavlink.abstract_mavlink.MavlinkActuator`.
-These classes provides a generic ``default`` implementation, so one just need
-to override the method ``make_msg`` (for sensors) and ``process_msg`` (for
+These classes provides a generic ``default`` implementation, so you just need
+to override the method ``make_msg`` (for sensors) or ``process_msg`` (for
 actuators). These methods must generate (or read) the ``self._msg`` field,
-which contains a message under Mavlink protocol. Another important thing (for
-documentation purpose) is to provide the ``_type_name`` for the class,
+which contains a message using the Mavlink protocol. It is also important (for
+documentation purposes) to provide the ``_type_name`` for the class,
 corresponding to the name of the associated Mavlink type. See for example the
 implementation for the attitude Mavlink message:
 


### PR DESCRIPTION
Personally, I'd change the my_repr variable's name to output or data throughout.

Also, in many places I'd have replaced "specific" with "custom".

You could consider adopting the new typing module's syntax, e.g., _type_name = typing.List[int, int, int], etc.

The - signs on lines 339, 340, 342, and 343 look wrong to me. Personally I never leave whitespace after a unary operator.