### PR TITLE
Corrected/improved the English + queries

### DIFF
--- a/doc/morse/dev/component_object_model.rst
+++ b/doc/morse/dev/component_object_model.rst
@@ -7,12 +7,12 @@ MORSE.
 .. image:: ../../media/morse_uml.png
    :align: center 
 
-The :py:class:`morse.core.abstractobject.AbstractObject` contains the logic to
-handle services (:tag:`service`). It contains also an ordered dictionary
-``local_data``, which is used to communicate between the different layer of
-Morse. It is important to have an ``OrderedDict`` and not a standard ``Dict``
-because order are used for some middleware serialization (and it is not well
-defined in the case of ``Dict``).
+The :py:class:`morse.core.abstractobject.AbstractObject` contains the logic for
+handling services (:tag:`service`). It also contains an ordered dictionary
+``local_data``, which is used to communicate between Morse's different layers.
+It is necessary to use an (insertion-ordered) ``OrderedDict`` and not a standard ``dict``
+because some middleware serialization depends on having a fixed reproducible key order (and this
+isn't possible with ``dict``).
 
 The :py:class:`morse.core.object.Object` contains the logic for ``real
 objects``. They own a reference to their associated blender object
@@ -20,9 +20,9 @@ objects``. They own a reference to their associated blender object
 about their spatial relation. 
 
 :py:class:`morse.core.sensor.Sensor` and
-:py:class:`morse.core.actuator.Actuator` are specialization of this class,
-respectively for sensor and actuator. They add some arrays to store their
-modifiers, and their datastream handlers, and override their ``action``
+:py:class:`morse.core.actuator.Actuator` are specializations of the :py:class:`morse.core.object.Object`class,
+for sensors and actuators. They add some arrays to store their
+modifiers, and their datastream handlers, and override their base class's ``action``
 method. See :doc:`this document <./execution_loop>` to learn what happens when
 these method are called.
 


### PR DESCRIPTION
Lines 19/20: I don't understand "and contain the basic logic about their spatial relation.".
Would "and contain the logic for positioning themselves." be a correct alternative?

Line 24. Do they really store arrays or are these Python lists?
