### PR TITLE
[src]Remove the trailing slash of the envi. name when using morse run

### DIFF
--- a/bin/morse.in
+++ b/bin/morse.in
@@ -339,6 +339,9 @@ def get_site(name):
     config = configparser.SafeConfigParser()
     config.read(get_config_file())
 
+    if name.endswith('/'):
+        name = name[:-1]
+
     if not config.has_option("sites", name):
         return None
 


### PR DESCRIPTION
When the environment to run is in $PWD, bash autocompletion causes the environment name to end with a trailing slash:

```bash
morse run the_env/
```

which throws an error:
```bash
* Cannot find a MORSE environment or simulation scene matching <the_env/>!
```

so simply detect it and remove it.