### PR TITLE
[cmake] add dependency from man to revisiontag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ ELSE()
 									   ${CMAKE_CURRENT_SOURCE_DIR}/doc/man
         								   ${SPHINX_MAN_OUTPUT} &&
 						  ${GZIP} -f ${SPHINX_MAN_OUTPUT}/*.1)
+		ADD_DEPENDENCIES(man revisiontag)
 		INSTALL(FILES ${SPHINX_MAN_OUTPUT}/morse.1.gz 
 					  ${SPHINX_MAN_OUTPUT}/morse-run.1.gz 
 					  ${SPHINX_MAN_OUTPUT}/morse-create.1.gz 


### PR DESCRIPTION
Without this the target can run before version.py is generated, causing the
build to fail. This has started happening in Debian/Ubuntu recently for some
unclear reason, but what is clear is that this only ever worked by chance.