### PR TITLE
ROS publisher queue_size

### DIFF
--- a/src/morse/middleware/ros/video_camera.py
+++ b/src/morse/middleware/ros/video_camera.py
@@ -21,7 +21,8 @@ class CameraPublisher(ROSPublisherTF):
         else:
             ROSPublisher.initialize(self)
         # Generate a publisher for the CameraInfo
-        self.topic_camera_info = rospy.Publisher(self.topic_name+'/camera_info', CameraInfo)
+        self.topic_camera_info = rospy.Publisher(self.topic_name+'/camera_info', CameraInfo,
+                                                 queue_size=self.determine_queue_size())
 
     def finalize(self):
         if self.pub_tf:


### PR DESCRIPTION
Automatically setting ros publisher queue_size in order to avoid a blocking simulation with slow or blocking subscribers.

queue_size should always be configured for a publisher. See here for some information about this:
http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers#queue_size:_publish.28.29_behavior_and_queuing

Without this fix I had an almost completely frozen simulation with a slow subscriber on a camera topic.