### PR TITLE
[mw/ros] Add support for static TF2 publisher (latched topic)

### DIFF
--- a/src/morse/middleware/ros/static_tf.py
+++ b/src/morse/middleware/ros/static_tf.py
@@ -1,5 +1,7 @@
 import logging; logger = logging.getLogger("morse." + __name__)
 from morse.middleware.ros import ROSPublisherTF
+from morse.middleware.ros.tfMessage import tfMessage
+
 import rospy
 
 class StaticTFPublisher(ROSPublisherTF):
@@ -25,3 +27,31 @@ class StaticTFPublisher(ROSPublisherTF):
             ts = rospy.Time.from_sec(self.data['timestamp'] + 1.0)
             self.send_transform_robot(ts, self.child_frame_id, self.parent_frame_id)
             self.last_ts = self.data['timestamp']
+
+
+class StaticTF2Publisher(StaticTFPublisher):
+    """ Publish the (static) transform between robot and this sensor/actuator, using a latched
+    topic (TF2 convention).
+    """
+    
+    topic_tf_static = None
+    init_tr = False
+
+    def initialize(self):
+        StaticTFPublisher.initialize(self)
+        if not StaticTF2Publisher.topic_tf_static:
+            StaticTF2Publisher.topic_tf_static = \
+                rospy.Publisher("/tf_static", tfMessage, queue_size=1, latch=True)
+
+
+    def default(self, ci='unused'):
+        if not self.init_tr and ('valid' not in self.data or self.data['valid']):
+            ts = rospy.Time.from_sec(0)
+            self.send_transform_robot(ts, self.child_frame_id, self.parent_frame_id)
+            self.init_tr = True
+
+    # TF publish method
+    def publish_tf(self, message):
+        """ Publish the TF data on the rostopic
+        """
+        StaticTF2Publisher.topic_tf_static.publish(message)

--- a/testing/middlewares/ros/tf_static_test.py
+++ b/testing/middlewares/ros/tf_static_test.py
@@ -1,0 +1,92 @@
+#! /usr/bin/env python
+"""
+This script tests that MORSE can generate valid tf frames.
+"""
+
+import sys
+import math
+from morse.testing.ros import RosTestCase
+from morse.testing.testing import testlogger
+
+from pymorse import Morse
+
+import rospy
+from morse.middleware.ros.tfMessage import tfMessage
+
+from time import sleep
+
+# Include this import to be able to use your test file as a regular 
+# builder script, ie, usable with: 'morse [run|exec] base_testing.py
+try:
+    from morse.builder import *
+except ImportError:
+    pass
+
+class StaticTfTest(RosTestCase):
+
+    def setUpEnv(self):
+        
+        robot = Morsy('morsy_test_1')
+        pose = Pose()
+        robot.append(pose)
+
+        pose.translate(0, 1, 2)
+        pose.add_stream('ros',
+            'morse.middleware.ros.static_tf.StaticTFPublisher')
+        pose.add_stream('ros',
+            'morse.middleware.ros.static_tf.StaticTF2Publisher')
+
+        env = Environment('empty', fastmode = True)
+
+        
+    def _callback(self, m, precision = 0.01):
+        t = m.transforms[0]
+        if t.child_frame_id != '/morsy_test_1/pose':
+            return
+        
+        p = t.transform.translation
+        self.assertAlmostEqual(p.x, 0.0, delta=precision)
+        self.assertAlmostEqual(p.y, 1.0, delta=precision)
+        self.assertAlmostEqual(p.z, 2.0, delta=precision)
+
+        m_time = t.header.stamp.to_sec()
+        if self.m_time is not None:
+            self.assertTrue(m_time > self.m_time + 1.0)
+
+        self.m_time = m_time
+        self.n_received += 1
+        
+
+    def test_static_tf(self):
+
+        rospy.init_node('morse_ros_static_tf_test')
+        
+        self.m_time = None
+        self.n_received = 0
+          
+        self.tf = rospy.Subscriber("/tf", tfMessage, self._callback,
+                                   queue_size = 1)
+
+        sleep(2.5)
+
+        self.assertTrue(self.n_received >= 2)
+
+
+    def test_static_tf2(self):
+        rospy.init_node('morse_ros_static_tf_test')
+
+        self.m_time = None
+        self.n_received = 0
+          
+        self.tf = rospy.Subscriber("/tf_static", tfMessage, self._callback,
+                                   queue_size = 1)
+
+        sleep(0.5)
+        
+        self.assertTrue(self.n_received == 1)
+
+        
+########################## Run these tests ##########################
+if __name__ == "__main__":
+    from morse.testing.testing import main
+    main(StaticTfTest, time_modes = [TimeStrategies.BestEffort])


### PR DESCRIPTION
Adding support for TF2 static publisher. As it uses a latched topic, and the transform is expected not to change, there is no need to broadcast it continuously.

See wiki.ros.org/tf2/Migration :

"*Addition of /tf_static topic*

For greater efficiency tf now has a static transform topic "/tf_static" This topic has the same format as "/tf" however it is expected that any transform on this topic can be considered true for all time. Internally any query for a static transform will return true.

It is expected that publishers on "/tf_static" publish using latched topics, the tf2_ros static_transform_publisher does this correctly. Note: avoid multiple latched static transform publishers on /tf_static in the same process, because with multiple latched publishers within the same node only one will latch correctly. "