### PR TITLE
Fixed and simplified create_new_material()

### DIFF
--- a/src/morse/builder/bpymorse.py
+++ b/src/morse/builder/bpymorse.py
@@ -91,11 +91,8 @@ def version():
 
 
 def create_new_material():
-    all_materials = get_materials().keys()
     new_material()
-    material_name = [name for name in get_materials().keys() \
-                     if name not in all_materials].pop()
-    return get_material(material_name)
+    return get_materials()[-1]
 
 def add_morse_empty(shape = 'ARROWS'):
     """Add MORSE Component Empty object which hlods MORSE logic"""


### PR DESCRIPTION
Fixed a problem that occured with some blender environments, the actual reason is unclear.

However, the included simplification of the create_new_material() method solved the problem.

The original problem stack trace was the following:

Exception ignored in: <bound method Environment.__del__ of <morse.builder.environment.Environment object at 0x7f94cce4a908>>
Traceback (most recent call last):
  File "/usr/local/lib/python3/dist-packages/morse/builder/environment.py", line 831, in __del__
    self.create()
  File "/usr/local/lib/python3/dist-packages/morse/builder/environment.py", line 300, in create
    component.after_renaming()
  File "/usr/local/lib/python3/dist-packages/morse/builder/sensors.py", line 290, in after_renaming
    self.create_laser_arc()
  File "/usr/local/lib/python3/dist-packages/morse/builder/sensors.py", line 283, in create_laser_arc
    arc.active_material = self.get_ray_material()
  File "/usr/local/lib/python3/dist-packages/morse/builder/sensors.py", line 186, in get_ray_material
    ray_material = bpymorse.create_new_material()
  File "/usr/local/lib/python3/dist-packages/morse/builder/bpymorse.py", line 96, in create_new_material
    material_name = [name for name in get_materials().keys() \
IndexError: pop from empty list