### PR TITLE
Keep all vlp points in the poincloud

### DIFF
--- a/src/morse/builder/sensors.py
+++ b/src/morse/builder/sensors.py
@@ -74,7 +74,7 @@ class IMU(SensorCreator):
         mesh.scale = (.04, .04, .02)
         mesh.color(.3, .9, .6)
         self.append(mesh)
-    
+
 class Magnetometer(SensorCreator):
     _classpath = "morse.sensors.magnetometer.Magnetometer"
 
@@ -476,12 +476,13 @@ class VLP16_180(DepthCameraAggregator):
         for i in range(3):
             cam = DepthCamera("cam%i"%i)
             """
-            cam_focal = 27.7 => hfov ~= 60.0. 
+            cam_focal = 27.7 => hfov ~= 60.0.
             As cam_height is half the cam_width, vfov ~= 30.0, so each pixel represent around 0.117°
             Hence, the keep_list is a reasonnably fair approximation of the real angle of VLP16
             """
             cam.properties(cam_width=512, cam_height=256, cam_focal = 27.7,
-                           keep_list=str([1, 17, 34, 51, 68, 85, 102, 120, 137, 154, 171, 188, 205, 222, 239, 255]))
+                           keep_list=str([1, 17, 34, 51, 68, 85, 102, 120, 137, 154, 171, 188, 205, 222, 239, 255]),
+                           keep_resolution=True)
             cam.rotate(x=(i-1) * math.pi / 3)
             cam.frequency(10)
             cam.hide_mesh()

--- a/src/morse/sensors/depth_camera.py
+++ b/src/morse/sensors/depth_camera.py
@@ -72,6 +72,10 @@ class DepthCamera(AbstractDepthCamera):
 "better simulate sparse sensor such as velodyne. If not specified, keep the "
 "image dense")
 
+    add_property('_keep_resolution', False, 'keep_resolution', 'boolean',
+    "By default the clipping of the camera removes unreals points"
+    "This option allows adding dummy points (0,0,0) for keeping the sensor resolution")
+
     def initialize(self):
         from morse.sensors.zbufferto3d import ZBufferTo3D
         if self._keep_list is None:
@@ -82,7 +86,7 @@ class DepthCamera(AbstractDepthCamera):
         self.converter = ZBufferTo3D(self.local_data['intrinsic_matrix'][0][0],
                                      self.local_data['intrinsic_matrix'][1][1],
                                      self.near_clipping, self.far_clipping,
-                                     self.image_width, self.image_height,
+                                     self.image_width, self.image_height, self._keep_resolution,
                                      keep_list)
 
     def process_image(self, image):


### PR DESCRIPTION
For HIL usage it is required to have a pointcloud with the complete resolution in order to serialize them depending on the sensor protocol we want to simulate. For this an option has been added in order to don't clip de camera far.