### PR TITLE
Change parameter names from `async` to `async_`

### DIFF
--- a/doc/morse/dev/services_internal.rst
+++ b/doc/morse/dev/services_internal.rst
@@ -65,7 +65,7 @@ Asynchronous services
 
 Registration of asynchronous services is almost the same as for synchronous
 services. The ``@async_service`` decorator simply calls the ``@service``
-decorator with the ``async`` parameter set to ``True``, which results in
+decorator with the ``asynchronous`` parameter set to ``True``, which results in
 the original method being wrapped in a new method that takes an extra parameter
 (a callback) and calls
 :py:meth:`morse.core.abstractobject.AbstractObject.set_service_callback`.
@@ -74,9 +74,9 @@ Simplified version of the ``@service`` decorator:
 
 .. code-block:: python
 
-    def service(fn, async=False):
+    def service(fn, asynchronous=False):
       dfn = fn
-      if async:
+      if asynchonous:
          def decorated_fn(self, callback, *param):
             self._set_service_callback(callback)
             fn(self, *param)

--- a/src/morse/core/request_manager.py
+++ b/src/morse/core/request_manager.py
@@ -137,7 +137,7 @@ class RequestManager(object):
         self.register_service(component_name, callback, service_name, True)
 
 
-    def register_service(self, component_name, callback, service_name = None, async = False):
+    def register_service(self, component_name, callback, service_name = None, asynchronous = False):
         """ Allows a component to register a synchronous RPC method that is made
         publicly available to the outside world.
 
@@ -146,10 +146,10 @@ class RequestManager(object):
                request.
                If service_name is not defined, it will also be used as
                the public name of the service.
-               If async is false (synchronous service), the method is expected to
+               If asynchronous is false (synchronous service), the method is expected to
                return immediately. In this case, its return value is immediately
                send back to the original caller.
-        :param boolean async: if true, the service is asynchronous: it can last for
+        :param boolean asynchronous: if true, the service is asynchronous: it can last for
                several cycles without blocking the communication interface.
                See :py:meth:`register_async_service` for details.
         :param service_name: if defined, service_name is used as public
@@ -159,11 +159,11 @@ class RequestManager(object):
         if hasattr(callback, '__call__'):
             service_name = service_name if service_name else callback.__name__
 
-            self._services[(component_name, service_name)] = (callback, async)
+            self._services[(component_name, service_name)] = (callback, asynchronous)
 
-            if self.post_registration(component_name, service_name, async):
+            if self.post_registration(component_name, service_name, asynchronous):
                 logger.info(str(self) + ": " + \
-                    ("Asynchronous" if async else "Synchronous") + \
+                    ("Asynchronous" if asynchronous else "Synchronous") + \
                     " service '" + service_name + "' for component '" + \
                     component_name + "' successfully registered")
             else:

--- a/src/morse/core/services.py
+++ b/src/morse/core/services.py
@@ -107,7 +107,7 @@ class MorseServices:
             instance.process()
 
 
-def do_service_registration(fn, component_name = None, service_name = None, async = False, request_managers = None):
+def do_service_registration(fn, component_name = None, service_name = None, asynchronous = False, request_managers = None):
 
     if blenderapi.fake: #doc mode
         return
@@ -122,7 +122,7 @@ def do_service_registration(fn, component_name = None, service_name = None, asyn
     for manager in request_managers:
         name = service_name if service_name else fn.__name__
         logger.debug("Registering service " + name + " in " + component_name + " (using " + manager.__class__.__name__ + ")")
-        manager.register_service(component_name, fn, name, async)
+        manager.register_service(component_name, fn, name, asynchronous)
 
 def async_service(fn = None, component = None, name = None):
     """  The @async_service decorator.
@@ -138,9 +138,9 @@ def async_service(fn = None, component = None, name = None):
       explaining why the initialization failed.  
 
       """
-    return service(fn, component, name, async = True)
+    return service(fn, component, name, asynchronous = True)
 
-def service(fn = None, component = None, name = None, async = False):
+def service(fn = None, component = None, name = None, asynchronous = False):
     """ The @service decorator.
 
     This decorator can be used to automagically register a service in
@@ -163,7 +163,7 @@ def service(fn = None, component = None, name = None, async = False):
       functions. Cf explanation above.
     :param string name: by default, the name of the service is the name
       of the method. You can override it by setting the 'name' argument.
-    :param boolean async: if set to True (default value when using 
+    :param boolean asynchronous: if set to True (default value when using
       @async_service), a new 'callback' parameter is added to the method.
       This callback is used to notify the service initiator that the service
       completed. The callback does not need to be build manually: 
@@ -180,7 +180,7 @@ def service(fn = None, component = None, name = None, async = False):
             # this method as a service.
             logger.debug("In @service: Decorating method "+ fn.__name__)
             dfn = fn
-            if async:
+            if asynchronous:
                 def decorated_fn(self, callback, *param):
                     # Stores in the callback the original calling
                     # service.
@@ -210,22 +210,22 @@ def service(fn = None, component = None, name = None, async = False):
 
             dfn._morse_service = True
             dfn._morse_service_name = name
-            dfn._morse_service_is_async = async
+            dfn._morse_service_is_async = asynchronous
 
             return dfn
 
         else:
-            if async:
+            if asynchronous:
                 logger.warning("asynchronous service must be declared within a MorseObject class.")
                 return
 
             logger.debug("In @service: Decorating free function "+ fn.__name__)
             # We assume it's a free function, and we register it.
-            do_service_registration(fn, component, name, async)
+            do_service_registration(fn, component, name, asynchronous)
             return fn
     else:
          # ...else, we build a new decorator
-        return partial(service, component = component, name = name, async = async)
+        return partial(service, component = component, name = name, asynchronous = asynchronous)
 
 def interruptible(fn):
     """ The @interruptible decorator.

--- a/src/morse/middleware/ros_request_manager.py
+++ b/src/morse/middleware/ros_request_manager.py
@@ -395,8 +395,8 @@ def ros_action(fn = None, type = None, name = None):
         return partial(ros_action, type = type, name = name)
         
     fn._ros_action_type = type
-    return services.service(fn, component = None, name = name, async = True)
-        
+    return services.service(fn, component = None, name = name, asynchronous = True)
+
 
 def ros_service(fn = None, type = None, component = None, name = None):
     """ The @ros_service decorator.
@@ -433,4 +433,4 @@ def ros_service(fn = None, type = None, component = None, name = None):
         return partial(ros_service, type = type, component = component, name = name)
 
     fn._ros_service_type = type
-    return services.service(fn, component = component, name = name, async = False)
+    return services.service(fn, component = component, name = name, asynchronous = False)


### PR DESCRIPTION
`async` became a keyword in python 3.7
PEP8 suggests: "single_trailing_underscore_: used by convention to avoid conflicts with Python keyword"
Thus the change to `async_`.

See also: #805