### PR TITLE
Build - fixed Windows compatibility and added build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,9 @@ option(BUILD_HLA_SUPPORT "Build HLA middleware support. Also used for distribute
 option(PYMORSE_SUPPORT "Build and install the Python bindings for MORSE." ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/config/)
-find_package(PkgConfig REQUIRED)
+IF(NOT WIN32)
+    find_package(PkgConfig REQUIRED)
+endif(NOT WIN32)
 
 set(PythonInterp_FIND_VERSION 3.3)
 find_package(PythonInterp REQUIRED)

--- a/INSTALL
+++ b/INSTALL
@@ -43,8 +43,7 @@ distributions.
 
 Other UNIXes systems probably work as well (like FreeBSD or Apple MacOSX).
 
-MORSE does not currently officially support Microsoft Windows, although some
-users reported success. Testers/maintainers for Windows are welcome!
+Windows is supported, but not fully tested.
 
 Packaged versions
 -----------------
@@ -94,15 +93,21 @@ Prerequisites
 - python-dev package
 - Blender (>= 2.65) build with Python >= 3.3. You can simply get a binary from
   Blender website
+  
+If building on Windows, ensure that your Python version and architecture matches
+the bundled Python in Blender (currently Python 3.5.3 for Blender 2.79).
 
 
 Installation
 ++++++++++++
 
+Linux
+-----
+
 Download the latest version of the source code. It is stored in a git
 repository::
 
-  $ git clone https://github.com/laas/morse.git
+  $ git clone https://github.com/morse-simulator/morse.git
 
 You can also get a tarball version here.
 
@@ -167,6 +172,26 @@ When updating MORSE to a more recent version, you'll simply have to do::
     $ git checkout [version]
     $ cd build
     $ make install
+
+Windows
+-------
+
+Download the latest version of the source code. It is stored in a git
+repository::
+
+  $ git clone https://github.com/morse-simulator/morse.git
+
+The MORSE_BLENDER environment variable should be set to the location and filename
+of the Blender executable (ie "C:\Program Files\Blender\blender.exe").
+
+Additionally, both cmake and Python should be on the system path.
+
+Go to the directory where you have previously downloaded the MORSE source.
+Then run the winbuild.bat script.
+
+By default, MORSE will install in C:\morse. You can easily change the
+install directory by editing the CMAKE_INSTALL_PREFIX variable in
+winbuild.bat
 
 Installation troubleshooting
 ----------------------------

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -13,6 +13,7 @@ General
   compute automatically the right time settings.  If you meet any problem
   related to time, make sure to read the Time and Event documentation and / or
   report issue to the Morse project.
+- Windows is now supported for building MORSE.
 
 Components
 ----------

--- a/doc/morse/user/installation.rst
+++ b/doc/morse/user/installation.rst
@@ -43,8 +43,7 @@ It should also work on UNIX systems more generally, such as FreeBSD and Apple Ma
 Some successful testing has been done on OSX 10.8 (see
 below for the Homebrew recipe).
 
-As yet, there is no official support for Microsoft Windows, although some
-users have reported success. Testers/maintainers for Windows are welcome!
+Windows is supported, but not fully tested.
 
 
 Hardware
@@ -121,9 +120,15 @@ Prerequisites
 .. note::
     If you use a Blender binary, numpy is included within it.
 
+.. note::
+    If building on Windows, ensure that your Python version and architecture matches
+    the bundled Python in Blender (currently Python 3.5.3 for Blender 2.79).
+
 Installation
 ++++++++++++
 
+Linux
+-----
 
 Clone with ``git`` or download the latest version of the source code::
 
@@ -160,6 +165,26 @@ You can check your configuration is okay with::
 
 Once MORSE is successfully installed and checked you are read for the
 :doc:`Quickstart<../quickstart>` tutorial!
+
+Windows
+-------
+
+Download the latest version of the source code. It is stored in a git
+repository::
+
+  $ git clone https://github.com/morse-simulator/morse.git
+
+The MORSE_BLENDER environment variable should be set the the location and filename
+of the Blender executable (ie "C:\Program Files\Blender\blender.exe").
+
+Additionally, both cmake and Python should be on the system path.
+
+Go to the directory where you have previously downloaded the MORSE source.
+Then run the winbuild.bat script.
+
+By default, MORSE will install in C:\morse. You can easily change the
+install directory by editing the CMAKE_INSTALL_PREFIX variable in
+winbuild.bat
 
 Middleware-specific notes
 +++++++++++++++++++++++++

--- a/src/morse/sensors/depthaggregator.c
+++ b/src/morse/sensors/depthaggregator.c
@@ -1,7 +1,6 @@
 #include <Python.h>
 #include "structmember.h"
 
-
 typedef struct {
     PyObject_HEAD
     // The buffer to return values
@@ -58,9 +57,6 @@ Aggregator_merge(PyAggregator* self, PyObject* args)
 
     int len = PyList_Size(listObj);
     int j = 0;
-
-    struct timeval begin, end, res;
-    gettimeofday(&begin, NULL);
 
     for (int i = 0; i < len; ++i)
     {

--- a/winbuild.bat
+++ b/winbuild.bat
@@ -1,0 +1,25 @@
+setlocal enableextensions
+
+rem ensure python 3.5 and cmake is on the system path, otherwise set them here
+rem Python 3.5 also needs the "numpy" package, install via the command "pip install numpy --user"
+rem ensure that the MORSE_BLENDER environment var is set to the blender.exe path+file
+rem Also note that Blender and Python must both be 32bit or both 64bit installs. They can't be different.
+rem you may also need a c compiler: "Microsoft Build Tools for Visual Studio 2017"
+
+rem get python paths
+for /f "delims=" %%i in ('python -c "from sysconfig import get_paths; print(get_paths()['include'])"') do set PYINC=%%i
+for /f "delims=" %%A in ('where python') do set PYTHONPATH=%%~dpA
+
+rem 32 or 64bit Python?
+for /f %%i in ('python -c "import struct; bit=8*struct.calcsize('P'); print('-DCMAKE_GENERATOR_PLATFORM=x64' if bit==64 else '')"') do set ISBIT=%%i
+
+rem only make the build folder if it doesn't exist
+if not exist "build" mkdir build
+
+rem and build and install into C:\morse
+rem if you want a different folder for more to be installed into, change the -DCMAKE_INSTALL_PREFIX="" below
+
+cd build
+cmake .. -DPYTHON_INCLUDE_DIR="%PYINC%" %ISBIT% -DPYTHON_LIBRARY="%PYTHONPATH%libs\python35.lib" -DCMAKE_INSTALL_PREFIX="C:\morse"
+cmake --build . --config Release --target install
+pause


### PR DESCRIPTION
Fixed up to compile/install/run in Windows sucessfully.

This comes out of some discussions in Ardupilot - The Ardupilot team has recently added support for the Morse simulator (https://discuss.ardupilot.org/t/morse-3d-simulator-with-ardupilot/35930)