### PR TITLE
Build - tests now run on Windows

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -190,7 +190,7 @@ Go to the directory where you have previously downloaded the MORSE source.
 Then run the winbuild.bat script.
 
 By default, MORSE will install in C:\morse. You can easily change the
-install directory by editing the CMAKE_INSTALL_PREFIX variable in
+install directory by editing the MORSE_ROOT variable in
 winbuild.bat
 
 Installation troubleshooting

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -13,7 +13,7 @@ General
   compute automatically the right time settings.  If you meet any problem
   related to time, make sure to read the Time and Event documentation and / or
   report issue to the Morse project.
-- Windows is now supported for building MORSE.
+- Windows is now supported for building MORSE and running the unit test suite.
 
 Components
 ----------

--- a/doc/morse/dev/testing.rst
+++ b/doc/morse/dev/testing.rst
@@ -110,6 +110,8 @@ This will start launching MORSE with a series of unit tests, to check that
 the creation of scenes and some of the components is running properly on your
 system.
 
+Windows users can run the ``winbuild.bat`` file to build and run the tests
+automatically.
 
 
 Running tests

--- a/doc/morse/user/installation.rst
+++ b/doc/morse/user/installation.rst
@@ -183,8 +183,8 @@ Go to the directory where you have previously downloaded the MORSE source.
 Then run the winbuild.bat script.
 
 By default, MORSE will install in C:\morse. You can easily change the
-install directory by editing the CMAKE_INSTALL_PREFIX variable in
-winbuild.bat
+install directory by editing the MORSE_ROOT variable in
+``winbuild.bat``
 
 Middleware-specific notes
 +++++++++++++++++++++++++

--- a/src/morse/testing/testing.py
+++ b/src/morse/testing/testing.py
@@ -2,7 +2,7 @@ import logging
 #testrunnerlogger = logging.getLogger("test.runner")
 testlogger = logging.getLogger("morsetesting.general")
 
-import sys, os
+import sys, os, platform
 from abc import ABCMeta, abstractmethod
 import unittest
 import inspect
@@ -201,11 +201,16 @@ class MorseTestCase(unittest.TestCase):
 
             if prefix == "":
                 cmd = 'morse'
+            elif platform.system() == 'Windows':
+                cmd = os.path.join(prefix.strip('\"').strip('\''), "bin", "morserun.py")
             else:
                 cmd = prefix + "/bin/morse"
 
             self.logfile = open(self.logfile_name, 'w')
-            self.morse_process = subprocess.Popen([cmd, 'run', temp_builder_script], stdout=self.logfile, stderr=subprocess.STDOUT)
+            if platform.system() == 'Windows':
+                self.morse_process = subprocess.Popen(['python', cmd, 'run', temp_builder_script], stdout=self.logfile, stderr=subprocess.STDOUT)
+            else:
+                self.morse_process = subprocess.Popen([cmd, 'run', temp_builder_script], stdout=self.logfile, stderr=subprocess.STDOUT)
         except OSError as ose:
             testlogger.error("Error while launching MORSE! Check you can run it from command-line\n" + \
                     " and if you use the $MORSE_ROOT env variable, check it points to a correct " + \

--- a/winbuild.bat
+++ b/winbuild.bat
@@ -17,9 +17,23 @@ rem only make the build folder if it doesn't exist
 if not exist "build" mkdir build
 
 rem and build and install into C:\morse
-rem if you want a different folder for more to be installed into, change the -DCMAKE_INSTALL_PREFIX="" below
+rem if you want a different folder for more to be installed into, change the MORSE_ROOT below
+set MORSE_ROOT=C:\morse
 
 cd build
-cmake .. -DPYTHON_INCLUDE_DIR="%PYINC%" %ISBIT% -DPYTHON_LIBRARY="%PYTHONPATH%libs\python35.lib" -DCMAKE_INSTALL_PREFIX="C:\morse"
+cmake .. -DPYMORSE_SUPPORT=ON -DPYTHON_INCLUDE_DIR="%PYINC%" %ISBIT% -DPYTHON_LIBRARY="%PYTHONPATH%libs\python35.lib" -DCMAKE_INSTALL_PREFIX="%MORSE_ROOT%" -DCMAKE_VERBOSE_MAKEFILE=ON
 cmake --build . --config Release --target install
+
+CHOICE /M "Run unit tests for 30min?"
+IF ERRORLEVEL 2 GOTO END
+IF ERRORLEVEL 1 GOTO RUNTESTS
+GOTO END
+
+:RUNTESTS
+rem the unit tests take ~30min to run, so optional for user to run these
+set PYTHONPATH=%PYTHONPATH%;%MORSE_ROOT%\Lib\site-packages\
+"C:\Program Files\CMake\bin\ctest" . --verbose -C Release
+GOTO END
+
+:END
 pause


### PR DESCRIPTION
Another Windows compatibility patch, this time to allow running of the tests.

Takes around 30min to run through them all, results here:
[morseouttest.txt](https://github.com/morse-simulator/morse/files/2689392/morseouttest.txt)

Most (73%) tests pass. The ones that fail are either due to missing middleware (ros, etc) on my computer or some yaw errors - I'm curious if this also occurs under Linux.