### PR TITLE
CI - patch for broken pip release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - activate test-environment
   - conda install -c conda-forge numpy
   - python -m pip install --upgrade pip
-  - pip install -U pywin32 pyinstaller setuptools packaging
+  - pip install -U pywin32 pyinstaller setuptools packaging --no-use-pep517
   
   #Set up build vars
   - for /f "delims=" %%i in ('python -c "from sysconfig import get_paths; print(get_paths()['include'])"') do set PYINC=%%i


### PR DESCRIPTION
Fix for #812.

The latest release of pip (19.0) causes an error when installing the pyinstaller & setuptools packages. Full details (and temporary fix) over at https://github.com/pypa/pip/issues/6163