### PR TITLE
removed leading slash for tf frames to avoid problems with tf2 migration

### DIFF
--- a/doc/morse/user/middlewares/ros.rst
+++ b/doc/morse/user/middlewares/ros.rst
@@ -35,4 +35,4 @@ Similarly, you can set a custom ``frame_id`` and ``child_frame_id``:
 
 .. code-block :: python
 
-    foo.add_stream('ros', frame_id = '/world', child_frame_id = '/footprint')
+    foo.add_stream('ros', frame_id = 'world', child_frame_id = 'footprint')

--- a/src/morse/middleware/ros/imu.py
+++ b/src/morse/middleware/ros/imu.py
@@ -4,7 +4,7 @@ from morse.middleware.ros import ROSPublisher
 class ImuPublisher(ROSPublisher):
     """ Publish the data of the IMU sensor (without covariance). """
     ros_class = Imu
-    default_frame_id = '/imu'
+    default_frame_id = 'imu'
 
     def default(self, ci='unused'):
         imu = Imu()

--- a/src/morse/middleware/ros/laserscanner.py
+++ b/src/morse/middleware/ros/laserscanner.py
@@ -8,7 +8,7 @@ from morse.middleware.ros import ROSPublisher, ROSPublisherTF
 class LaserScanPublisher(ROSPublisher):
     """ Publish the ``range_list`` of the laser scanner. """
     ros_class = LaserScan
-    default_frame_id = '/base_laser_link'
+    default_frame_id = 'base_laser_link'
 
     def default(self, ci='unused'):
         laserscan = LaserScan()

--- a/src/morse/middleware/ros/odometry.py
+++ b/src/morse/middleware/ros/odometry.py
@@ -10,12 +10,12 @@ class OdometryPublisher(ROSPublisherTF):
     '/base_footprint' through TF.
     """
     ros_class = Odometry
-    default_frame_id = '/odom'
+    default_frame_id = 'odom'
 
     def initialize(self):
         ROSPublisherTF.initialize(self)
         # store the frame ids
-        self.child_frame_id = self.kwargs.get("child_frame_id", "/base_footprint")
+        self.child_frame_id = self.kwargs.get("child_frame_id", "base_footprint")
 
         logger.info("Initialized the ROS odometry sensor with frame_id '%s' " +\
                     "and child_frame_id '%s'", self.frame_id, self.child_frame_id)

--- a/src/morse/middleware/ros/pose.py
+++ b/src/morse/middleware/ros/pose.py
@@ -66,7 +66,7 @@ class PoseStampedPublisher(ROSPublisher):
     as ROS geometry_msgs.PoseStamped message.
     """
     ros_class = PoseStamped
-    default_frame_id = '/map'
+    default_frame_id = 'map'
 
     def default(self, ci='unused'):
         if 'valid' not in self.data or self.data['valid']:
@@ -79,7 +79,7 @@ class PoseStampedPublisher(ROSPublisher):
 class PoseWithCovarianceStampedPublisher(ROSPublisher):
     """ Publish the position and orientation of the robot including the covariance. """
     ros_class = PoseWithCovarianceStamped
-    default_frame_id = '/map'
+    default_frame_id = 'map'
 
     def default(self, ci='unused'):
         if 'valid' not in self.data or self.data['valid']:
@@ -96,12 +96,12 @@ class TFPublisher(ROSPublisherTF):
     ``frame_id`` and ``child_frame_id`` args, default '/map' and
     '/base_link' through TF.
     """
-    default_frame_id = '/map'
+    default_frame_id = 'map'
 
     def initialize(self):
         ROSPublisherTF.initialize(self)
         # store the frame ids
-        self.child_frame_id = self.kwargs.get("child_frame_id", "/base_link")
+        self.child_frame_id = self.kwargs.get("child_frame_id", "base_link")
 
         logger.info("Initialized the ROS TF publisher with frame_id '%s' " + \
                     "and child_frame_id '%s'", self.frame_id, self.child_frame_id)

--- a/src/morse/middleware/ros/semantic_camera.py
+++ b/src/morse/middleware/ros/semantic_camera.py
@@ -13,7 +13,7 @@ class SemanticCameraPublisher(ROSPublisherTF):
 
     def initialize(self):
         if not self.component_instance.relative:
-            self.default_frame_id = '/map'
+            self.default_frame_id = 'map'
         ROSPublisherTF.initialize(self)
 
     def default(self, ci='unused'):
@@ -36,7 +36,7 @@ class SemanticCameraPublisherLisp(ROSPublisherTF):
 
     def initialize(self):
         if not self.component_instance.relative:
-            self.default_frame_id = '/map'
+            self.default_frame_id = 'map'
         ROSPublisherTF.initialize(self)
 
     def default(self, ci='unused'):

--- a/src/morse/middleware/ros/velocity.py
+++ b/src/morse/middleware/ros/velocity.py
@@ -5,7 +5,7 @@ from morse.middleware.ros import ROSPublisher
 class TwistStampedPublisher(ROSPublisher):
     """ Publish the twist of the robot. """
     ros_class = TwistStamped
-    default_frame_id = '/base_link'
+    default_frame_id = 'base_link'
 
     def default(self, ci='unused'):
         twist = TwistStamped()

--- a/testing/middlewares/ros/tf_static_test.py
+++ b/testing/middlewares/ros/tf_static_test.py
@@ -41,7 +41,7 @@ class StaticTfTest(RosTestCase):
         
     def _callback(self, m, precision = 0.01):
         t = m.transforms[0]
-        if t.child_frame_id != '/morsy_test_1/pose':
+        if t.child_frame_id != 'morsy_test_1/pose':
             return
         
         p = t.transform.translation


### PR DESCRIPTION
see here for some related information:
http://wiki.ros.org/tf2/Migration#Removal_of_support_for_tf_prefix

The problem became obvious when we migrated from kinetic to melodic, where we ran into errors from the ROS navigation stack (move_base), I assume they also migrated from tf to tf2, which was causing those issues.

I tried to find all places in the source base that have a leading slash and corrected it.